### PR TITLE
feat: prepare aggregate api sdk

### DIFF
--- a/smartling-api-sdk-all/pom.xml
+++ b/smartling-api-sdk-all/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <artifactId>smartling-api-sdk</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
     <name>Smartling API SDK</name>
     <dependencies>
         <dependency>

--- a/smartling-api-sdk-all/src/main/java/com/smartling/api/sdk/SmartlingApi.java
+++ b/smartling-api-sdk-all/src/main/java/com/smartling/api/sdk/SmartlingApi.java
@@ -1,0 +1,8 @@
+package com.smartling.api.sdk;
+
+import com.smartling.sdk.authorization.AuthorizationApi;
+
+public interface SmartlingApi
+    extends AuthorizationApi
+{
+}

--- a/smartling-api-sdk-all/src/main/java/com/smartling/api/sdk/SmartlingApiFactory.java
+++ b/smartling-api-sdk-all/src/main/java/com/smartling/api/sdk/SmartlingApiFactory.java
@@ -1,0 +1,12 @@
+package com.smartling.api.sdk;
+
+import com.smartling.api.v2.client.AbstractApiFactory;
+
+public class SmartlingApiFactory extends AbstractApiFactory<SmartlingApi>
+{
+    @Override
+    protected Class<SmartlingApi> getApiClass()
+    {
+        return SmartlingApi.class;
+    }
+}


### PR DESCRIPTION
I added the authorization API, which I may remove, but wanted to use as an example. This PR introduces the aggregator project which provides all our APIs under a single SDK for customers that need the full SDK. However, individual SDKs will continue to be sub-projects as I documented on the wiki. This allows:

* Individual APIs that can be consumed internally, or by a customer who just needs partial functionality.
* Customers who want the full public SDK can use smartling-api-sdk-all which will have all our APIs under one project (we could rename, the artifact is actually `smartling-api-sdk`)
* Internal SDKs will extend functionality of individual modules rather than the aggregate. This will simplify versioning and scope in dealing with internal only APIs.

More to come tomorrow on Slack but I want to make sure you guys are good to start contributing ASAP. The SDK is ready for new sub-projects now. I'll work on release management this week. 