### PR TITLE
build: validate JavaDocs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
             - checkout
             - run:
                   name: Build & Test
-                  command: './mvnw clean test'
+                  command: './mvnw clean test javadoc:javadoc'
             - run:
                   name: Collect Test Results
                   command: |


### PR DESCRIPTION
Maven release plugin fails if JavaDocs are invalid. Check JavaDocs
on pull requests to avoid publishing issues.