### PR TITLE
feat: Job Batches API v1

### DIFF
--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/util/FileUploadClientFactory.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/util/FileUploadClientFactory.java
@@ -1,4 +1,4 @@
-package com.smartling.api.jobbatches.v2;
+package com.smartling.api.jobbatches.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.smartling.api.v2.client.ClientFactory;

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/util/FileUploadProxyUtils.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/util/FileUploadProxyUtils.java
@@ -1,0 +1,150 @@
+package com.smartling.api.jobbatches.util;
+
+import com.smartling.api.v2.client.exception.RestApiExceptionHandler;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpStatus;
+import org.jboss.resteasy.annotations.providers.multipart.PartFilename;
+import org.jboss.resteasy.annotations.providers.multipart.PartType;
+import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import org.jboss.resteasy.client.jaxrs.internal.ClientResponse;
+import org.jboss.resteasy.plugins.providers.multipart.FieldEnablerPrivilegedAction;
+import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
+
+import javax.ws.rs.FormParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.util.Map;
+
+@Slf4j
+public class FileUploadProxyUtils
+{
+    private static final String CLIENT_LIB_ID = "smartling.client_lib_id";
+
+    public static void addClientLibIdIfNeeded(MultipartFormDataOutput requestData)
+    {
+        if (!requestData.getFormData().containsKey(CLIENT_LIB_ID))
+        {
+            String clientLibId = LibNameVersionHolder.getClientLibName() + "/" + LibNameVersionHolder.getClientLibVersion();
+            requestData.addFormData(CLIENT_LIB_ID, clientLibId, MediaType.TEXT_PLAIN_TYPE);
+        }
+    }
+
+    public static Response sendRequest(ResteasyWebTarget client, String path, String projectId, String batchUid, MultipartFormDataOutput output)
+    {
+        RestApiExceptionHandler exceptionHandler = new RestApiExceptionHandler();
+        try
+        {
+            Response response = client.path(path)
+                .resolveTemplate("projectId", projectId)
+                .resolveTemplate("batchUid", batchUid)
+                .request()
+                .post(Entity.entity(output, MediaType.MULTIPART_FORM_DATA));
+            if (response.getStatus() != HttpStatus.SC_ACCEPTED)
+            {
+                throw new WebApplicationException(response);
+            }
+            return response;
+        }
+        catch (WebApplicationException e)
+        {
+            throw exceptionHandler.createRestApiException(e);
+        }
+    }
+
+
+    public static void getFields(Class<?> type, MultipartFormDataOutput output, Object obj)
+    {
+        for (Field field : type.getDeclaredFields())
+        {
+            AccessController.doPrivileged(new FieldEnablerPrivilegedAction(field));
+            Object value = getFieldValue(field, obj);
+            if (value == null)
+            {
+                continue;
+            }
+            if (field.isAnnotationPresent(FormParam.class) && field.isAnnotationPresent(PartType.class))
+            {
+                FormParam param = field.getAnnotation(FormParam.class);
+                PartType partType = field.getAnnotation(PartType.class);
+                String filename = getFilename(field);
+
+                output.addFormData(param.value(), value, field.getType(), field.getGenericType(), MediaType.valueOf(partType.value()), filename);
+            }
+            if (field.getType().isAssignableFrom(Map.class))
+            {
+                Map<String, String> directives = (Map<String, String>) getFieldValue(field, obj);
+                if (directives == null)
+                {
+                    continue;
+                }
+                for (Map.Entry<String, String> entry : directives.entrySet())
+                {
+                    if (entry.getValue() == null)
+                    {
+                        continue;
+                    }
+                    output.addFormData(entry.getKey(), entry.getValue(), MediaType.TEXT_PLAIN_TYPE);
+                }
+            }
+        }
+    }
+
+    public static void releaseConnection(Response response)
+    {
+        if (response instanceof ClientResponse)
+        {
+            try
+            {
+                ((ClientResponse) response).releaseConnection();
+            }
+            catch (IOException e)
+            {
+                log.warn("Failed to release connection for response", e);
+            }
+        }
+    }
+
+    private static String getFilename(AccessibleObject method)
+    {
+        PartFilename fname = method.getAnnotation(PartFilename.class);
+        return fname == null ? null : fname.value();
+    }
+
+    private static Object getFieldValue(Field field, Object obj)
+    {
+        try
+        {
+            return field.get(obj);
+        }
+        catch (IllegalAccessException e)
+        {
+            return null;
+        }
+    }
+
+    public static String getPathAnnotationValue(Class<?> clazz, String methodName, Class<?>... methodParameterTypes)
+    {
+        Method method;
+        try
+        {
+            method = clazz.getMethod(methodName, methodParameterTypes);
+            if (method.isAnnotationPresent(Path.class))
+            {
+                return method.getAnnotation(Path.class).value();
+            }
+        }
+        catch (NoSuchMethodException e)
+        {
+            return "";
+        }
+        return "";
+    }
+}

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/FileUploadProxy.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/FileUploadProxy.java
@@ -1,0 +1,107 @@
+package com.smartling.api.jobbatches.v1;
+
+import com.smartling.api.jobbatches.v1.pto.BatchActionRequestPTO;
+import com.smartling.api.jobbatches.v1.pto.BatchPTO;
+import com.smartling.api.jobbatches.v1.pto.BatchStatusResponsePTO;
+import com.smartling.api.jobbatches.v1.pto.CreateBatchRequestPTO;
+import com.smartling.api.jobbatches.v1.pto.CreateBatchResponsePTO;
+import com.smartling.api.jobbatches.v1.pto.FileUploadPTO;
+import com.smartling.api.jobbatches.v1.pto.SearchParamsPTO;
+import com.smartling.api.jobbatches.v1.pto.StreamFileUploadPTO;
+import com.smartling.api.v2.response.ListResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
+
+import javax.ws.rs.core.Response;
+
+import static com.smartling.api.jobbatches.util.FileUploadProxyUtils.addClientLibIdIfNeeded;
+import static com.smartling.api.jobbatches.util.FileUploadProxyUtils.getFields;
+import static com.smartling.api.jobbatches.util.FileUploadProxyUtils.getPathAnnotationValue;
+import static com.smartling.api.jobbatches.util.FileUploadProxyUtils.releaseConnection;
+import static com.smartling.api.jobbatches.util.FileUploadProxyUtils.sendRequest;
+
+@Slf4j
+public class FileUploadProxy implements JobBatchesApi
+{
+    private JobBatchesApi delegate;
+    private ResteasyWebTarget client;
+
+    FileUploadProxy(JobBatchesApi delegate, ResteasyWebTarget client)
+    {
+        this.delegate = delegate;
+        this.client = client;
+    }
+
+    @Override
+    public CreateBatchResponsePTO createBatch(String projectId, CreateBatchRequestPTO createBatchRequest)
+    {
+        return delegate.createBatch(projectId, createBatchRequest);
+    }
+
+    @Override
+    public BatchStatusResponsePTO getBatchStatus(String projectId, String batchUid)
+    {
+        return delegate.getBatchStatus(projectId, batchUid);
+    }
+
+    @Override
+    public ListResponse<BatchPTO> listBatches(String projectId, SearchParamsPTO searchParams)
+    {
+        return delegate.listBatches(projectId, searchParams);
+    }
+
+    @Override
+    public void addFile(String projectId, String batchUid, FileUploadPTO fileUploadPTO)
+    {
+        MultipartFormDataOutput output = new MultipartFormDataOutput();
+        getFields(FileUploadPTO.class, output, fileUploadPTO);
+        addClientLibIdIfNeeded(output);
+
+        String path = getPathAnnotationValue(JobBatchesApi.class, "addFile", String.class, String.class, FileUploadPTO.class);
+        Response response = sendRequest(client, path, projectId, batchUid, output);
+        releaseConnection(response);
+    }
+
+    @Override
+    public void addFileAsStream(String projectId, String batchUid, StreamFileUploadPTO streamFileUploadPTO)
+    {
+        MultipartFormDataOutput output = new MultipartFormDataOutput();
+        getFields(StreamFileUploadPTO.class, output, streamFileUploadPTO);
+        addClientLibIdIfNeeded(output);
+
+        String path = getPathAnnotationValue(JobBatchesApi.class, "addFileAsStream", String.class, String.class, StreamFileUploadPTO.class);
+        Response response = sendRequest(client, path, projectId, batchUid, output);
+        releaseConnection(response);
+    }
+
+    @Override
+    public void executeBatch(String projectId, String batchUid, BatchActionRequestPTO request)
+    {
+        delegate.executeBatch(projectId, batchUid, request);
+    }
+
+    @Override
+    public void addFileAsync(String projectId, String batchUid, FileUploadPTO fileUploadPTO)
+    {
+        MultipartFormDataOutput output = new MultipartFormDataOutput();
+        getFields(FileUploadPTO.class, output, fileUploadPTO);
+        addClientLibIdIfNeeded(output);
+
+        String path = getPathAnnotationValue(JobBatchesApi.class, "addFileAsync", String.class, String.class, FileUploadPTO.class);
+        Response response = sendRequest(client, path, projectId, batchUid, output);
+        releaseConnection(response);
+    }
+
+    @Override
+    public void addFileAsStreamAsync(String projectId, String batchUid, StreamFileUploadPTO streamFileUploadPTO)
+    {
+        MultipartFormDataOutput output = new MultipartFormDataOutput();
+        getFields(StreamFileUploadPTO.class, output, streamFileUploadPTO);
+        addClientLibIdIfNeeded(output);
+
+        String path = getPathAnnotationValue(JobBatchesApi.class, "addFileAsStreamAsync", String.class, String.class, StreamFileUploadPTO.class);
+        Response response = sendRequest(client, path, projectId, batchUid, output);
+        releaseConnection(response);
+    }
+}

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/JobBatchesApi.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/JobBatchesApi.java
@@ -1,0 +1,62 @@
+package com.smartling.api.jobbatches.v1;
+
+import com.smartling.api.jobbatches.v1.pto.BatchActionRequestPTO;
+import com.smartling.api.jobbatches.v1.pto.BatchPTO;
+import com.smartling.api.jobbatches.v1.pto.CreateBatchRequestPTO;
+import com.smartling.api.jobbatches.v1.pto.BatchStatusResponsePTO;
+import com.smartling.api.jobbatches.v1.pto.CreateBatchResponsePTO;
+import com.smartling.api.jobbatches.v1.pto.FileUploadPTO;
+import com.smartling.api.jobbatches.v1.pto.SearchParamsPTO;
+import com.smartling.api.jobbatches.v1.pto.StreamFileUploadPTO;
+import com.smartling.api.v2.response.ListResponse;
+import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
+
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public interface JobBatchesApi
+{
+    @POST
+    @Path("job-batches-api/v1/projects/{projectId}/batches")
+    CreateBatchResponsePTO createBatch(@PathParam("projectId") String projectId, CreateBatchRequestPTO createBatchRequest);
+
+    @GET
+    @Path("job-batches-api/v1/projects/{projectId}/batches/{batchUid}")
+    BatchStatusResponsePTO getBatchStatus(@PathParam("projectId") String projectId, @PathParam("batchUid") String batchUid);
+
+    @GET
+    @Path("job-batches-api/v1/projects/{projectId}/batches")
+    ListResponse<BatchPTO> listBatches(@PathParam("projectId") String projectId, @BeanParam SearchParamsPTO searchParams);
+
+    @POST
+    @Path("job-batches-api/v1/projects/{projectId}/batches/{batchUid}/file")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    void addFile(@PathParam("projectId") String projectId, @PathParam("batchUid") String batchUid, @MultipartForm FileUploadPTO fileUploadPTO);
+
+    @POST
+    @Path("job-batches-api/v1/projects/{projectId}/batches/{batchUid}/file")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    void addFileAsStream(@PathParam("projectId") String projectId, @PathParam("batchUid") String batchUid, @MultipartForm StreamFileUploadPTO streamFileUploadPTO);
+
+    @POST
+    @Path("job-batches-api/v2/projects/{projectId}/batches/{batchUid}/file")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    void addFileAsync(@PathParam("projectId") String projectId, @PathParam("batchUid") String batchUid, @MultipartForm FileUploadPTO fileUploadPTO);
+
+    @POST
+    @Path("job-batches-api/v2/projects/{projectId}/batches/{batchUid}/file")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    void addFileAsStreamAsync(@PathParam("projectId") String projectId, @PathParam("batchUid") String batchUid, @MultipartForm StreamFileUploadPTO streamFileUploadPTO);
+
+    @POST
+    @Path("job-batches-api/v1/projects/{projectId}/batches/{batchUid}")
+    void executeBatch(@PathParam("projectId") String projectId, @PathParam("batchUid") String batchUid, BatchActionRequestPTO request);
+}

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/JobBatchesApiFactory.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/JobBatchesApiFactory.java
@@ -1,0 +1,61 @@
+package com.smartling.api.jobbatches.v1;
+
+import com.smartling.api.jobbatches.util.FileUploadClientFactory;
+import com.smartling.api.jobbatches.util.LibNameVersionHolder;
+import com.smartling.api.v2.client.AbstractApiFactory;
+import com.smartling.api.v2.client.HttpClientConfiguration;
+import org.apache.http.HttpHeaders;
+import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import java.util.ArrayList;
+import java.util.List;
+
+public class JobBatchesApiFactory extends AbstractApiFactory<JobBatchesApi>
+{
+    private static final int FILE_UPLOAD_SOCKET_TIMEOUT = 30_000;
+
+    @Override
+    protected Class<JobBatchesApi> getApiClass()
+    {
+        return JobBatchesApi.class;
+    }
+
+    @Override
+    public JobBatchesApi buildApi(List<ClientRequestFilter> filterList, String hostAndProtocol, HttpClientConfiguration httpClientConfiguration)
+    {
+        if (httpClientConfiguration.getSocketTimeout() == HttpClientConfiguration.DEFAULT_SOCKET_TIMEOUT)
+        {
+            httpClientConfiguration.setSocketTimeout(FILE_UPLOAD_SOCKET_TIMEOUT);
+        }
+
+        List<ClientRequestFilter> clientRequestFilters = new ArrayList<>(filterList.size() + 1);
+        clientRequestFilters.addAll(filterList);
+        clientRequestFilters.add(userAgentFilter());
+
+        JobBatchesApi jobBatchesApi = super.buildApi(clientRequestFilters, hostAndProtocol, httpClientConfiguration);
+        ResteasyWebTarget client = new FileUploadClientFactory().build(clientRequestFilters, hostAndProtocol, httpClientConfiguration);
+
+        return new FileUploadProxy(jobBatchesApi, client);
+    }
+
+    private ClientRequestFilter userAgentFilter()
+    {
+        return new ClientRequestFilter()
+        {
+            @Override
+            public void filter(ClientRequestContext clientRequestContext)
+            {
+                try
+                {
+                    clientRequestContext.getHeaders().add(HttpHeaders.USER_AGENT,
+                            LibNameVersionHolder.getClientLibName() + "/" + LibNameVersionHolder.getClientLibVersion());
+                }
+                catch (Exception ignored)
+                {
+                }
+            }
+        };
+    }
+}

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/pto/BatchActionRequestPTO.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/pto/BatchActionRequestPTO.java
@@ -1,0 +1,18 @@
+package com.smartling.api.jobbatches.v1.pto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BatchActionRequestPTO
+{
+    private final String action = "execute";
+    private List<WorkflowPTO> localeWorkflows;
+}

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/pto/BatchItemLocalePTO.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/pto/BatchItemLocalePTO.java
@@ -1,0 +1,16 @@
+package com.smartling.api.jobbatches.v1.pto;
+
+import com.smartling.api.v2.response.ResponseData;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BatchItemLocalePTO implements ResponseData
+{
+    private String localeId;
+    private int stringsAdded;
+    private int stringsSkipped;
+}

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/pto/BatchItemPTO.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/pto/BatchItemPTO.java
@@ -1,0 +1,21 @@
+package com.smartling.api.jobbatches.v1.pto;
+
+import com.smartling.api.v2.response.ResponseData;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Calendar;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BatchItemPTO implements ResponseData
+{
+    private String status;
+    private Calendar updatedDate;
+    private String errors;
+    private String fileUri;
+    private List<BatchItemLocalePTO> targetLocales;
+}

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/pto/BatchPTO.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/pto/BatchPTO.java
@@ -1,0 +1,23 @@
+package com.smartling.api.jobbatches.v1.pto;
+
+import com.smartling.api.v2.response.ResponseData;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Calendar;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BatchPTO implements ResponseData
+{
+    private String batchUid;
+    private String status;
+    private Boolean authorized;
+    private String translationJobUid;
+    private String projectId;
+    private Calendar createdDate;
+    private Calendar modifiedDate;
+    private Boolean hasError;
+}

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/pto/BatchStatusResponsePTO.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/pto/BatchStatusResponsePTO.java
@@ -1,0 +1,23 @@
+package com.smartling.api.jobbatches.v1.pto;
+
+import com.smartling.api.v2.response.ResponseData;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Calendar;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BatchStatusResponsePTO implements ResponseData
+{
+    private String status;
+    private Boolean authorized;
+    private String generalErrors;
+    private String translationJobUid;
+    private String projectId;
+    private Calendar updatedDate;
+    private List<BatchItemPTO> files;
+}

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/pto/CreateBatchRequestPTO.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/pto/CreateBatchRequestPTO.java
@@ -1,0 +1,16 @@
+package com.smartling.api.jobbatches.v1.pto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateBatchRequestPTO
+{
+    private String translationJobUid;
+    private Boolean authorize;
+}

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/pto/CreateBatchResponsePTO.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/pto/CreateBatchResponsePTO.java
@@ -1,0 +1,14 @@
+package com.smartling.api.jobbatches.v1.pto;
+
+import com.smartling.api.v2.response.ResponseData;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateBatchResponsePTO implements ResponseData
+{
+    private String batchUid;
+}

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/pto/FileUploadPTO.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/pto/FileUploadPTO.java
@@ -1,0 +1,50 @@
+package com.smartling.api.jobbatches.v1.pto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.jboss.resteasy.annotations.providers.multipart.PartFilename;
+import org.jboss.resteasy.annotations.providers.multipart.PartType;
+
+import javax.ws.rs.FormParam;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FileUploadPTO
+{
+    @FormParam("fileType")
+    @PartType("text/plain")
+    private String fileType;
+
+    @FormParam("fileUri")
+    @PartType("text/plain")
+    private String fileUri;
+
+    @FormParam("authorize")
+    @PartType("text/plain")
+    private Boolean authorize;
+
+    @FormParam("callbackUrl")
+    @PartType("text/plain")
+    private String callbackUrl;
+
+    @FormParam("localeIdsToAuthorize[]")
+    @PartType("text/plain")
+    private List<String> localeIdsToAuthorize;
+
+    @FormParam("charset")
+    @PartType("text/plain")
+    private String charset;
+
+    @FormParam("file")
+    @PartType("application/octet-stream")
+    @PartFilename("file")
+    private byte[] file;
+
+    private Map<String, String> directives;
+}

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/pto/SearchParamsPTO.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/pto/SearchParamsPTO.java
@@ -1,0 +1,33 @@
+package com.smartling.api.jobbatches.v1.pto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.ws.rs.QueryParam;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SearchParamsPTO
+{
+    @QueryParam("offset")
+    private Integer offset;
+
+    @QueryParam("limit")
+    private Integer limit;
+
+    @QueryParam("sortBy")
+    private String sortBy;
+
+    @QueryParam("orderBy")
+    private String orderBy;
+
+    @QueryParam("status")
+    private String status;
+
+    @QueryParam("translationJobUid")
+    private String translationJobUid;
+}

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/pto/StreamFileUploadPTO.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/pto/StreamFileUploadPTO.java
@@ -1,0 +1,51 @@
+package com.smartling.api.jobbatches.v1.pto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.jboss.resteasy.annotations.providers.multipart.PartFilename;
+import org.jboss.resteasy.annotations.providers.multipart.PartType;
+
+import javax.ws.rs.FormParam;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StreamFileUploadPTO
+{
+    @FormParam("fileType")
+    @PartType("text/plain")
+    private String fileType;
+
+    @FormParam("fileUri")
+    @PartType("text/plain")
+    private String fileUri;
+
+    @FormParam("authorize")
+    @PartType("text/plain")
+    private Boolean authorize;
+
+    @FormParam("callbackUrl")
+    @PartType("text/plain")
+    private String callbackUrl;
+
+    @FormParam("localeIdsToAuthorize[]")
+    @PartType("text/plain")
+    private List<String> localeIdsToAuthorize;
+
+    @FormParam("charset")
+    @PartType("text/plain")
+    private String charset;
+
+    @FormParam("file")
+    @PartType("application/octet-stream")
+    @PartFilename("file")
+    private InputStream file;
+
+    private Map<String, String> directives;
+}

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/pto/WorkflowPTO.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v1/pto/WorkflowPTO.java
@@ -1,0 +1,16 @@
+package com.smartling.api.jobbatches.v1.pto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WorkflowPTO
+{
+    private String targetLocaleId;
+    private String workflowUid;
+}

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v2/FileUploadProxy.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v2/FileUploadProxy.java
@@ -1,44 +1,30 @@
 package com.smartling.api.jobbatches.v2;
 
+import com.smartling.api.jobbatches.v2.pto.BatchPTO;
 import com.smartling.api.jobbatches.v2.pto.BatchStatusResponsePTO;
 import com.smartling.api.jobbatches.v2.pto.CancelBatchActionRequestPTO;
 import com.smartling.api.jobbatches.v2.pto.CreateBatchRequestPTO;
 import com.smartling.api.jobbatches.v2.pto.CreateBatchResponsePTO;
-import com.smartling.api.jobbatches.v2.pto.RegisterBatchActionRequestPTO;
-import com.smartling.api.jobbatches.v2.pto.StreamFileUploadPTO;
-import com.smartling.api.jobbatches.util.LibNameVersionHolder;
-import com.smartling.api.v2.client.exception.RestApiExceptionHandler;
-import com.smartling.api.jobbatches.v2.pto.BatchPTO;
 import com.smartling.api.jobbatches.v2.pto.FileUploadPTO;
+import com.smartling.api.jobbatches.v2.pto.RegisterBatchActionRequestPTO;
 import com.smartling.api.jobbatches.v2.pto.SearchParamsPTO;
+import com.smartling.api.jobbatches.v2.pto.StreamFileUploadPTO;
 import com.smartling.api.v2.response.ListResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.http.HttpStatus;
-import org.jboss.resteasy.annotations.providers.multipart.PartFilename;
-import org.jboss.resteasy.annotations.providers.multipart.PartType;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
-import org.jboss.resteasy.client.jaxrs.internal.ClientResponse;
-import org.jboss.resteasy.plugins.providers.multipart.FieldEnablerPrivilegedAction;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
 
-import javax.ws.rs.FormParam;
-import javax.ws.rs.Path;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.io.IOException;
-import java.lang.reflect.AccessibleObject;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.security.AccessController;
-import java.util.Map;
+
+import static com.smartling.api.jobbatches.util.FileUploadProxyUtils.addClientLibIdIfNeeded;
+import static com.smartling.api.jobbatches.util.FileUploadProxyUtils.getFields;
+import static com.smartling.api.jobbatches.util.FileUploadProxyUtils.getPathAnnotationValue;
+import static com.smartling.api.jobbatches.util.FileUploadProxyUtils.releaseConnection;
+import static com.smartling.api.jobbatches.util.FileUploadProxyUtils.sendRequest;
 
 @Slf4j
 public class FileUploadProxy implements JobBatchesApi
 {
-    private static final String CLIENT_LIB_ID = "smartling.client_lib_id";
-
     private JobBatchesApi delegate;
     private ResteasyWebTarget client;
 
@@ -73,8 +59,8 @@ public class FileUploadProxy implements JobBatchesApi
         getFields(FileUploadPTO.class, output, fileUploadPTO);
         addClientLibIdIfNeeded(output);
 
-        String path = getPathAnnotationValue("addFileAsync", String.class, String.class, FileUploadPTO.class);
-        Response response = sendRequest(path, projectId, batchUid, output);
+        String path = getPathAnnotationValue(JobBatchesApi.class,"addFileAsync", String.class, String.class, FileUploadPTO.class);
+        Response response = sendRequest(client, path, projectId, batchUid, output);
         releaseConnection(response);
     }
 
@@ -85,8 +71,8 @@ public class FileUploadProxy implements JobBatchesApi
         getFields(StreamFileUploadPTO.class, output, streamFileUploadPTO);
         addClientLibIdIfNeeded(output);
 
-        String path = getPathAnnotationValue("addFileAsStreamAsync", String.class, String.class, StreamFileUploadPTO.class);
-        Response response = sendRequest(path, projectId, batchUid, output);
+        String path = getPathAnnotationValue(JobBatchesApi.class,"addFileAsStreamAsync", String.class, String.class, StreamFileUploadPTO.class);
+        Response response = sendRequest(client, path, projectId, batchUid, output);
         releaseConnection(response);
     }
 
@@ -98,124 +84,5 @@ public class FileUploadProxy implements JobBatchesApi
     @Override
     public void cancelFile(String projectId, String batchUid, CancelBatchActionRequestPTO request) {
         delegate.cancelFile(projectId, batchUid, request);
-    }
-
-    private void addClientLibIdIfNeeded(MultipartFormDataOutput requestData)
-    {
-        if (!requestData.getFormData().containsKey(CLIENT_LIB_ID))
-        {
-            String clientLibId = LibNameVersionHolder.getClientLibName() + "/" + LibNameVersionHolder.getClientLibVersion();
-            requestData.addFormData(CLIENT_LIB_ID, clientLibId, MediaType.TEXT_PLAIN_TYPE);
-        }
-    }
-
-    private Response sendRequest(String path, String projectId, String batchUid, MultipartFormDataOutput output)
-    {
-        RestApiExceptionHandler exceptionHandler = new RestApiExceptionHandler();
-        try
-        {
-            Response response = client.path(path)
-                .resolveTemplate("projectId", projectId)
-                .resolveTemplate("batchUid", batchUid)
-                .request()
-                .post(Entity.entity(output, MediaType.MULTIPART_FORM_DATA));
-            if (response.getStatus() != HttpStatus.SC_ACCEPTED)
-            {
-                throw new WebApplicationException(response);
-            }
-            return response;
-        }
-        catch (WebApplicationException e)
-        {
-            throw exceptionHandler.createRestApiException(e);
-        }
-    }
-
-    private void getFields(Class<?> type, MultipartFormDataOutput output, Object obj)
-    {
-        for (Field field : type.getDeclaredFields())
-        {
-            AccessController.doPrivileged(new FieldEnablerPrivilegedAction(field));
-            Object value = getFieldValue(field, obj);
-            if (value == null)
-            {
-                continue;
-            }
-            if (field.isAnnotationPresent(FormParam.class) && field.isAnnotationPresent(PartType.class))
-            {
-                FormParam param = field.getAnnotation(FormParam.class);
-                PartType partType = field.getAnnotation(PartType.class);
-                String filename = getFilename(field);
-
-                output.addFormData(param.value(), value, field.getType(), field.getGenericType(), MediaType.valueOf(partType.value()), filename);
-            }
-            if (field.getType().isAssignableFrom(Map.class))
-            {
-                Map<String, String> directives = (Map<String, String>) getFieldValue(field, obj);
-                if (directives == null)
-                {
-                    continue;
-                }
-                for (Map.Entry<String, String> entry : directives.entrySet())
-                {
-                    if (entry.getValue() == null)
-                    {
-                        continue;
-                    }
-                    output.addFormData(entry.getKey(), entry.getValue(), MediaType.TEXT_PLAIN_TYPE);
-                }
-            }
-        }
-    }
-
-    private void releaseConnection(Response response)
-    {
-        if (response instanceof ClientResponse)
-        {
-            try
-            {
-                ((ClientResponse) response).releaseConnection();
-            }
-            catch (IOException e)
-            {
-                log.warn("Failed to release connection for response", e);
-            }
-        }
-    }
-
-    private String getFilename(AccessibleObject method)
-    {
-        PartFilename fname = method.getAnnotation(PartFilename.class);
-        return fname == null ? null : fname.value();
-    }
-
-    private Object getFieldValue(Field field, Object obj)
-    {
-        try
-        {
-            return field.get(obj);
-        }
-        catch (IllegalAccessException e)
-        {
-            return null;
-        }
-    }
-
-    private String getPathAnnotationValue(String methodName, Class<?>... methodParameterTypes)
-    {
-        Method method;
-        try
-        {
-            method = JobBatchesApi.class.getMethod(methodName, methodParameterTypes);
-            if (method.isAnnotationPresent(Path.class))
-            {
-                return method.getAnnotation(Path.class).value();
-            }
-        }
-        catch (NoSuchMethodException e)
-        {
-            return "";
-        }
-        return "";
     }
 }

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v2/JobBatchesApi.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v2/JobBatchesApi.java
@@ -22,37 +22,37 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-@Produces (MediaType.APPLICATION_JSON)
-@Consumes (MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 public interface JobBatchesApi
 {
     @POST
     @Path("job-batches-api/v2/projects/{projectId}/batches")
-    CreateBatchResponsePTO createBatch(@PathParam ("projectId")String projectId, CreateBatchRequestPTO createBatchRequest);
+    CreateBatchResponsePTO createBatch(@PathParam("projectId") String projectId, CreateBatchRequestPTO createBatchRequest);
 
     @GET
-    @Path ("job-batches-api/v2/projects/{projectId}/batches/{batchUid}")
-    BatchStatusResponsePTO getBatchStatus(@PathParam("projectId")String projectId, @PathParam ("batchUid") String batchUid);
+    @Path("job-batches-api/v2/projects/{projectId}/batches/{batchUid}")
+    BatchStatusResponsePTO getBatchStatus(@PathParam("projectId") String projectId, @PathParam("batchUid") String batchUid);
 
     @GET
     @Path("job-batches-api/v2/projects/{projectId}/batches")
-    ListResponse<BatchPTO> listBatches(@PathParam("projectId")String projectId, @BeanParam SearchParamsPTO searchParams);
+    ListResponse<BatchPTO> listBatches(@PathParam("projectId") String projectId, @BeanParam SearchParamsPTO searchParams);
 
     @POST
-    @Path ("job-batches-api/v2/projects/{projectId}/batches/{batchUid}/file")
-    @Consumes (MediaType.MULTIPART_FORM_DATA)
+    @Path("job-batches-api/v2/projects/{projectId}/batches/{batchUid}/file")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
     void addFileAsync(@PathParam("projectId") String projectId, @PathParam("batchUid") String batchUid, @MultipartForm FileUploadPTO fileUploadPTO);
 
     @POST
-    @Path ("job-batches-api/v2/projects/{projectId}/batches/{batchUid}/file")
-    @Consumes (MediaType.MULTIPART_FORM_DATA)
+    @Path("job-batches-api/v2/projects/{projectId}/batches/{batchUid}/file")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
     void addFileAsStreamAsync(@PathParam("projectId") String projectId, @PathParam("batchUid") String batchUid, @MultipartForm StreamFileUploadPTO streamFileUploadPTO);
 
     @PUT
-    @Path ("job-batches-api/v2/projects/{projectId}/batches/{batchUid}")
+    @Path("job-batches-api/v2/projects/{projectId}/batches/{batchUid}")
     void registerFile(@PathParam("projectId") String projectId, @PathParam("batchUid") String batchUid, RegisterBatchActionRequestPTO request);
 
     @PUT
-    @Path ("job-batches-api/v2/projects/{projectId}/batches/{batchUid}")
+    @Path("job-batches-api/v2/projects/{projectId}/batches/{batchUid}")
     void cancelFile(@PathParam("projectId") String projectId, @PathParam("batchUid") String batchUid, CancelBatchActionRequestPTO request);
 }

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v2/JobBatchesApiFactory.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v2/JobBatchesApiFactory.java
@@ -1,5 +1,6 @@
 package com.smartling.api.jobbatches.v2;
 
+import com.smartling.api.jobbatches.util.FileUploadClientFactory;
 import com.smartling.api.jobbatches.util.LibNameVersionHolder;
 import com.smartling.api.v2.client.AbstractApiFactory;
 import com.smartling.api.v2.client.HttpClientConfiguration;

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v2/pto/SearchParamsPTO.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/v2/pto/SearchParamsPTO.java
@@ -15,14 +15,19 @@ public class SearchParamsPTO
 {
     @QueryParam("offset")
     private Integer offset;
+
     @QueryParam("limit")
     private Integer limit;
+
     @QueryParam("sortBy")
-    private String sortBy ;
+    private String sortBy;
+
     @QueryParam("orderBy")
     private String orderBy;
+
     @QueryParam("status")
     private String status;
+
     @QueryParam("translationJobUid")
     private String translationJobUid;
 }

--- a/smartling-job-batches-api/src/test/java/com/smartling/api/jobbatches/v1/JobBatchesApiTest.java
+++ b/smartling-job-batches-api/src/test/java/com/smartling/api/jobbatches/v1/JobBatchesApiTest.java
@@ -1,0 +1,83 @@
+package com.smartling.api.jobbatches.v1;
+
+import com.smartling.api.jobbatches.v1.pto.CreateBatchRequestPTO;
+import com.smartling.api.jobbatches.v1.pto.CreateBatchResponsePTO;
+import com.smartling.api.v2.client.auth.BearerAuthStaticTokenFilter;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.apache.http.HttpStatus;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.core.HttpHeaders;
+
+import static javax.ws.rs.HttpMethod.POST;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JobBatchesApiTest
+{
+    private final String SUCCESS_RESPONSE_ENVELOPE = "{\"response\":{\"code\":\"SUCCESS\",\"data\":%s}})";
+
+    private static final String PROJECT_ID = "4bca2a7b8";
+
+    private MockWebServer mockWebServer;
+    private JobBatchesApi jobBatchesApi;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        final JobBatchesApiFactory factory = new JobBatchesApiFactory();
+        final BearerAuthStaticTokenFilter tokenFilter = new BearerAuthStaticTokenFilter("foo");
+
+        jobBatchesApi = factory.buildApi(tokenFilter, mockWebServer.url("/").toString());
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        mockWebServer.shutdown();
+    }
+
+    private void assignResponse(final int httpStatusCode, final String body)
+    {
+        final MockResponse response = new MockResponse()
+            .setResponseCode(httpStatusCode)
+            .setHeader(HttpHeaders.CONTENT_LENGTH, body.length())
+            .setHeader(HttpHeaders.CONTENT_TYPE, "application/json; charset=utf-8")
+            .setBody(body);
+
+        mockWebServer.enqueue(response);
+    }
+
+    @Test
+    public void testCreateBatch() throws Exception
+    {
+        assignResponse(HttpStatus.SC_OK, String.format(SUCCESS_RESPONSE_ENVELOPE, "{\"batchUid\" : \"createdBatchUid\"}"));
+
+        // language=JSON
+        String requestString = "{"
+            + "\"translationJobUid\":\"jobUid\","
+            + "\"authorize\":true"
+            + "}";
+
+        CreateBatchRequestPTO requestBody = CreateBatchRequestPTO.builder()
+            .translationJobUid("jobUid")
+            .authorize(true)
+            .build();
+
+        CreateBatchResponsePTO response = jobBatchesApi.createBatch(PROJECT_ID, requestBody);
+
+        assertEquals("createdBatchUid", response.getBatchUid());
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertEquals(POST, request.getMethod());
+        assertEquals(requestString, request.getBody().readUtf8());
+        assertTrue(request.getPath().startsWith(("/job-batches-api/v1/projects/" + PROJECT_ID + "/batches")));
+    }
+}


### PR DESCRIPTION
Quick background
v1 and v2 use different approaches
v1 requires synchronous files upload, with finalizing batch "execution" after all uploads, 
v2 - asynchronous, with automatic "execution", requires knowing the number of files to be uploaded at the time of batch creation.
We support v1 because not all integrations can use v2, one of our connectors can't