### PR TITLE
fix: don't rewrap auth errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,12 @@
             <version>3.0.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>2.26.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -98,28 +104,28 @@
                     <release>7</release>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
-                <configuration>
-                    <gpgArguments>
-                        <gpgArgument>--no-tty</gpgArgument>
-                        <gpgArgument>--batch</gpgArgument>
-                        <gpgArgument>--pinentry-mode</gpgArgument>
-                        <gpgArgument>loopback</gpgArgument>
-                    </gpgArguments>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-gpg-plugin</artifactId>-->
+<!--                <version>1.6</version>-->
+<!--                <configuration>-->
+<!--                    <gpgArguments>-->
+<!--                        <gpgArgument>&#45;&#45;no-tty</gpgArgument>-->
+<!--                        <gpgArgument>&#45;&#45;batch</gpgArgument>-->
+<!--                        <gpgArgument>&#45;&#45;pinentry-mode</gpgArgument>-->
+<!--                        <gpgArgument>loopback</gpgArgument>-->
+<!--                    </gpgArguments>-->
+<!--                </configuration>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <id>sign-artifacts</id>-->
+<!--                        <phase>verify</phase>-->
+<!--                        <goals>-->
+<!--                            <goal>sign</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--            </plugin>-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -104,28 +104,28 @@
                     <release>7</release>
                 </configuration>
             </plugin>
-<!--            <plugin>-->
-<!--                <groupId>org.apache.maven.plugins</groupId>-->
-<!--                <artifactId>maven-gpg-plugin</artifactId>-->
-<!--                <version>1.6</version>-->
-<!--                <configuration>-->
-<!--                    <gpgArguments>-->
-<!--                        <gpgArgument>&#45;&#45;no-tty</gpgArgument>-->
-<!--                        <gpgArgument>&#45;&#45;batch</gpgArgument>-->
-<!--                        <gpgArgument>&#45;&#45;pinentry-mode</gpgArgument>-->
-<!--                        <gpgArgument>loopback</gpgArgument>-->
-<!--                    </gpgArguments>-->
-<!--                </configuration>-->
-<!--                <executions>-->
-<!--                    <execution>-->
-<!--                        <id>sign-artifacts</id>-->
-<!--                        <phase>verify</phase>-->
-<!--                        <goals>-->
-<!--                            <goal>sign</goal>-->
-<!--                        </goals>-->
-<!--                    </execution>-->
-<!--                </executions>-->
-<!--            </plugin>-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.6</version>
+                <configuration>
+                    <gpgArguments>
+                        <gpgArgument>--no-tty</gpgArgument>
+                        <gpgArgument>--batch</gpgArgument>
+                        <gpgArgument>--pinentry-mode</gpgArgument>
+                        <gpgArgument>loopback</gpgArgument>
+                    </gpgArguments>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>

--- a/smartling-api-commons/src/main/java/com/smartling/api/v2/client/exception/DefaultRestApiExceptionMapper.java
+++ b/smartling-api-commons/src/main/java/com/smartling/api/v2/client/exception/DefaultRestApiExceptionMapper.java
@@ -40,7 +40,14 @@ public class DefaultRestApiExceptionMapper implements RestApiExceptionMapper
                     restApiRuntimeException = new NotFoundErrorException(throwable, response, errorResponse);
                     break;
                 case VALIDATION_ERROR:
-                    restApiRuntimeException = new ValidationErrorException(throwable, response, errorResponse);
+                    if (response.getStatus() == 401)
+                    {
+                        restApiRuntimeException = new AuthenticationErrorException(throwable, response, errorResponse);
+                    }
+                    else
+                    {
+                        restApiRuntimeException = new ValidationErrorException(throwable, response, errorResponse);
+                    }
                     break;
                 case MAX_OPERATIONS_LIMIT_EXCEEDED:
                     restApiRuntimeException = new TooManyRequestsException(throwable, response, errorResponse);

--- a/smartling-api-commons/src/main/java/com/smartling/api/v2/client/exception/DefaultRestApiExceptionMapper.java
+++ b/smartling-api-commons/src/main/java/com/smartling/api/v2/client/exception/DefaultRestApiExceptionMapper.java
@@ -13,10 +13,9 @@ import com.smartling.api.v2.client.exception.server.ServiceBusyErrorException;
 import com.smartling.api.v2.response.ErrorResponse;
 import com.smartling.api.v2.response.ResponseCode;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpStatus;
 
 import javax.ws.rs.core.Response;
-
-import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 
 @Slf4j
 public class DefaultRestApiExceptionMapper implements RestApiExceptionMapper
@@ -42,11 +41,11 @@ public class DefaultRestApiExceptionMapper implements RestApiExceptionMapper
                     restApiRuntimeException = new NotFoundErrorException(throwable, response, errorResponse);
                     break;
                 case VALIDATION_ERROR:
-                    if (response.getStatus() == 401)
+                    if (response.getStatus() == HttpStatus.SC_UNAUTHORIZED)
                     {
                         restApiRuntimeException = new AuthenticationErrorException(throwable, response, errorResponse);
                     }
-                    else if (response.getStatus() == SC_NOT_FOUND)
+                    else if (response.getStatus() == HttpStatus.SC_NOT_FOUND)
                     {
                         restApiRuntimeException = new NotFoundErrorException(throwable, response, errorResponse);
                     }

--- a/smartling-api-commons/src/main/java/com/smartling/api/v2/client/exception/DefaultRestApiExceptionMapper.java
+++ b/smartling-api-commons/src/main/java/com/smartling/api/v2/client/exception/DefaultRestApiExceptionMapper.java
@@ -41,18 +41,7 @@ public class DefaultRestApiExceptionMapper implements RestApiExceptionMapper
                     restApiRuntimeException = new NotFoundErrorException(throwable, response, errorResponse);
                     break;
                 case VALIDATION_ERROR:
-                    if (response.getStatus() == HttpStatus.SC_UNAUTHORIZED)
-                    {
-                        restApiRuntimeException = new AuthenticationErrorException(throwable, response, errorResponse);
-                    }
-                    else if (response.getStatus() == HttpStatus.SC_NOT_FOUND)
-                    {
-                        restApiRuntimeException = new NotFoundErrorException(throwable, response, errorResponse);
-                    }
-                    else
-                    {
-                        restApiRuntimeException = new ValidationErrorException(throwable, response, errorResponse);
-                    }
+                    restApiRuntimeException = toExceptionByStatus(throwable, response, errorResponse);
                     break;
                 case MAX_OPERATIONS_LIMIT_EXCEEDED:
                     restApiRuntimeException = new TooManyRequestsException(throwable, response, errorResponse);
@@ -82,6 +71,24 @@ public class DefaultRestApiExceptionMapper implements RestApiExceptionMapper
             restApiRuntimeException = createGenericException(throwable, response, errorResponse);
         }
 
+        return restApiRuntimeException;
+    }
+
+    private RestApiRuntimeException toExceptionByStatus(Throwable throwable, Response response, ErrorResponse errorResponse)
+    {
+        RestApiRuntimeException restApiRuntimeException;
+        switch (response.getStatus())
+        {
+            case HttpStatus.SC_UNAUTHORIZED:
+                restApiRuntimeException = new AuthenticationErrorException(throwable, response, errorResponse);
+                break;
+            case HttpStatus.SC_NOT_FOUND:
+                restApiRuntimeException = new NotFoundErrorException(throwable, response, errorResponse);
+                break;
+            default:
+                restApiRuntimeException = new ValidationErrorException(throwable, response, errorResponse);
+                break;
+        }
         return restApiRuntimeException;
     }
 

--- a/smartling-api-commons/src/main/java/com/smartling/api/v2/client/exception/DefaultRestApiExceptionMapper.java
+++ b/smartling-api-commons/src/main/java/com/smartling/api/v2/client/exception/DefaultRestApiExceptionMapper.java
@@ -16,6 +16,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.ws.rs.core.Response;
 
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+
 @Slf4j
 public class DefaultRestApiExceptionMapper implements RestApiExceptionMapper
 {
@@ -43,6 +45,10 @@ public class DefaultRestApiExceptionMapper implements RestApiExceptionMapper
                     if (response.getStatus() == 401)
                     {
                         restApiRuntimeException = new AuthenticationErrorException(throwable, response, errorResponse);
+                    }
+                    else if (response.getStatus() == SC_NOT_FOUND)
+                    {
+                        restApiRuntimeException = new NotFoundErrorException(throwable, response, errorResponse);
                     }
                     else
                     {

--- a/smartling-api-commons/src/main/java/com/smartling/api/v2/client/exception/RestApiExceptionHandler.java
+++ b/smartling-api-commons/src/main/java/com/smartling/api/v2/client/exception/RestApiExceptionHandler.java
@@ -3,10 +3,10 @@ package com.smartling.api.v2.client.exception;
 import com.smartling.api.v2.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 
-import java.lang.reflect.InvocationTargetException;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
+import java.lang.reflect.InvocationTargetException;
 
 @Slf4j
 public class RestApiExceptionHandler
@@ -29,6 +29,10 @@ public class RestApiExceptionHandler
             final ErrorResponse errorResponse = getErrorResponse(response);
 
             restApiRuntimeException = exceptionMapper.toException(throwable, response, errorResponse);
+        }
+        else if (throwable instanceof ProcessingException && throwable.getCause() instanceof RestApiRuntimeException)
+        {
+            restApiRuntimeException = (RestApiRuntimeException)throwable.getCause();
         }
         else
         {

--- a/smartling-api-commons/src/test/java/com/smartling/api/v2/auth/AuthenticationIntegrationTest.java
+++ b/smartling-api-commons/src/test/java/com/smartling/api/v2/auth/AuthenticationIntegrationTest.java
@@ -11,7 +11,7 @@ import com.smartling.api.v2.client.DefaultClientConfiguration;
 import com.smartling.api.v2.client.auth.Authenticator;
 import com.smartling.api.v2.client.auth.BearerAuthSecretFilter;
 import com.smartling.api.v2.client.exception.RestApiRuntimeException;
-import com.smartling.api.v2.client.exception.client.ValidationErrorException;
+import com.smartling.api.v2.client.exception.client.AuthenticationErrorException;
 import com.smartling.api.v2.client.exception.server.MaintanenceModeErrorException;
 import com.smartling.api.v2.client.exception.server.ServerApiException;
 import org.junit.Before;
@@ -134,7 +134,7 @@ public class AuthenticationIntegrationTest
             )
         );
 
-        thrown.expect(ValidationErrorException.class);
+        thrown.expect(AuthenticationErrorException.class);
 
         dummyApi("invalidUser", "invalidSecret").dummy();
 

--- a/smartling-api-commons/src/test/java/com/smartling/api/v2/auth/AuthenticationIntegrationTest.java
+++ b/smartling-api-commons/src/test/java/com/smartling/api/v2/auth/AuthenticationIntegrationTest.java
@@ -1,0 +1,203 @@
+package com.smartling.api.v2.auth;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.smartling.api.v2.authentication.AuthenticationApi;
+import com.smartling.api.v2.authentication.AuthenticationApiFactory;
+import com.smartling.api.v2.client.AbstractApiFactory;
+import com.smartling.api.v2.client.ApiFactory;
+import com.smartling.api.v2.client.ClientConfiguration;
+import com.smartling.api.v2.client.ClientFactory;
+import com.smartling.api.v2.client.DefaultClientConfiguration;
+import com.smartling.api.v2.client.auth.Authenticator;
+import com.smartling.api.v2.client.auth.BearerAuthSecretFilter;
+import com.smartling.api.v2.client.exception.RestApiRuntimeException;
+import com.smartling.api.v2.client.exception.client.ValidationErrorException;
+import com.smartling.api.v2.client.exception.server.MaintanenceModeErrorException;
+import com.smartling.api.v2.client.exception.server.ServerApiException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.net.URL;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
+import static com.github.tomakehurst.wiremock.client.WireMock.unauthorized;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.smartling.api.v2.auth.DummyApi.DUMMY_API;
+
+public class AuthenticationIntegrationTest
+{
+    @Rule
+    public WireMockRule smartlingApi = new WireMockRule();
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private ApiFactory<DummyApi> dummyFactory = new AbstractApiFactory<DummyApi>()
+    {
+        @Override
+        protected Class<DummyApi> getApiClass()
+        {
+            return DummyApi.class;
+        }
+    };
+
+    @Before
+    public void setup()
+    {
+        smartlingApi.stubFor(get(urlEqualTo(DUMMY_API)).willReturn(ok()));
+    }
+
+    private DummyApi dummyApi() throws Exception
+    {
+        return dummyApi("user", "secret");
+    }
+
+    private DummyApi dummyApi(String user, String secret) throws Exception
+    {
+        ClientFactory clientFactory = new ClientFactory();
+        ClientConfiguration configuration = DefaultClientConfiguration.builder()
+            .baseUrl(new URL(smartlingApi.baseUrl()))
+            .build();
+        AuthenticationApi authenticationApi = new AuthenticationApiFactory(clientFactory)
+            .buildApi(configuration);
+        Authenticator authenticator = new Authenticator(user, secret, authenticationApi);
+
+        return dummyFactory.buildApi(new BearerAuthSecretFilter(authenticator), configuration);
+    }
+
+    @Test
+    public void shouldAuthenticate() throws Exception
+    {
+        smartlingApi.stubFor(post(urlEqualTo("/auth-api/v2/authenticate"))
+            .withHeader("Content-Type", equalTo("application/json"))
+            .withRequestBody(equalToJson("{\n" +
+                "  \"userIdentifier\": \"user\",\n" +
+                "  \"userSecret\": \"secret\"\n" +
+                "}")
+            )
+            // language=JSON
+            .willReturn(okJson("{\n" +
+                "  \"response\": {\n" +
+                "    \"code\": \"SUCCESS\",\n" +
+                "    \"data\": {\n" +
+                "      \"accessToken\": \"accessTokenValue\",\n" +
+                "      \"refreshToken\": \"refreshTokenValue\",\n" +
+                "      \"expiresIn\": 480,\n" +
+                "      \"refreshExpiresIn\": 21600,\n" +
+                "      \"tokenType\": \"Bearer\"\n" +
+                "    }\n" +
+                "  }\n" +
+                "}")
+            )
+        );
+
+        dummyApi().dummy();
+
+        smartlingApi.verify(getRequestedFor(urlEqualTo(DUMMY_API))
+            .withHeader("Authorization", equalTo("Bearer accessTokenValue")));
+    }
+
+    @Test
+    public void shouldThrowValidationErrorExceptionOnInvalidCredentials() throws Exception
+    {
+        smartlingApi.stubFor(post(urlEqualTo("/auth-api/v2/authenticate"))
+            .withHeader("Content-Type", equalTo("application/json"))
+            .withRequestBody(equalToJson("{\n" +
+                "  \"userIdentifier\": \"invalidUser\",\n" +
+                "  \"userSecret\": \"invalidSecret\"\n" +
+                "}")
+            )
+            .willReturn(unauthorized()
+                .withHeader("Content-Type", "application/json")
+                // language=JSON
+                .withBody("{\n" +
+                    "  \"response\": {\n" +
+                    "    \"code\": \"VALIDATION_ERROR\",\n" +
+                    "    \"errors\": [\n" +
+                    "      {\n" +
+                    "        \"key\": null,\n" +
+                    "        \"message\": \"HTTP 401 Unauthorized\",\n" +
+                    "        \"details\": null\n" +
+                    "      }\n" +
+                    "    ]\n" +
+                    "  }\n" +
+                    "}\n")
+            )
+        );
+
+        thrown.expect(ValidationErrorException.class);
+
+        dummyApi("invalidUser", "invalidSecret").dummy();
+
+        smartlingApi.verify(0, getRequestedFor(urlEqualTo(DUMMY_API)));
+    }
+
+    @Test
+    public void shouldThrowServerApiException() throws Exception
+    {
+        smartlingApi.stubFor(post(urlEqualTo("/auth-api/v2/authenticate"))
+            .willReturn(serverError()
+            .withHeader("Content-Type", "application/json")
+            // language=JSON
+            .withBody("{\n" +
+                "  \"response\": {\n" +
+                "    \"code\": \"GENERAL_ERROR\",\n" +
+                "    \"errors\": []\n" +
+                "  }\n" +
+                "}")
+            )
+        );
+
+        thrown.expect(ServerApiException.class);
+
+        dummyApi().dummy();
+
+        smartlingApi.verify(0, getRequestedFor(urlEqualTo(DUMMY_API)));
+    }
+
+    @Test
+    public void shouldThrowMaintanenceModeErrorException() throws Exception
+    {
+        smartlingApi.stubFor(post(urlEqualTo("/auth-api/v2/authenticate"))
+            .willReturn(serverError()
+                .withHeader("Content-Type", "application/json")
+                // language=JSON
+                .withBody("{\n" +
+                    "  \"response\": {\n" +
+                    "    \"code\": \"MAINTENANCE_MODE_ERROR\",\n" +
+                    "    \"errors\": []\n" +
+                    "  }\n" +
+                    "}")
+            )
+        );
+
+        thrown.expect(MaintanenceModeErrorException.class);
+
+        dummyApi().dummy();
+
+        smartlingApi.verify(0, getRequestedFor(urlEqualTo(DUMMY_API)));
+    }
+
+
+    @Test
+    public void shouldThrowGenericRuntimeException() throws Exception
+    {
+        smartlingApi.stubFor(post(urlEqualTo("/auth-api/v2/authenticate"))
+            .willReturn(serverError()));
+
+        thrown.expect(RestApiRuntimeException.class);
+
+        dummyApi().dummy();
+
+        smartlingApi.verify(0, getRequestedFor(urlEqualTo(DUMMY_API)));
+    }
+}

--- a/smartling-api-commons/src/test/java/com/smartling/api/v2/auth/AuthenticationIntegrationTest.java
+++ b/smartling-api-commons/src/test/java/com/smartling/api/v2/auth/AuthenticationIntegrationTest.java
@@ -14,6 +14,7 @@ import com.smartling.api.v2.client.exception.RestApiRuntimeException;
 import com.smartling.api.v2.client.exception.server.MaintanenceModeErrorException;
 import com.smartling.api.v2.client.exception.server.ServerApiException;
 import com.smartling.api.v2.response.ResponseCode;
+import org.apache.http.HttpStatus;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.junit.Before;
@@ -168,11 +169,11 @@ public class AuthenticationIntegrationTest
                     "    \"details\": null\n" +
                     "  }\n" +
                     "]")
-                .withStatus(401)
+                .withStatus(HttpStatus.SC_UNAUTHORIZED)
             )
         );
 
-        thrown.expect(new ExceptionMatcher(401, "http_status=401, top errors: 'HTTP 401 Unauthorized'"));
+        thrown.expect(new ExceptionMatcher(HttpStatus.SC_UNAUTHORIZED, "http_status=401, top errors: 'HTTP 401 Unauthorized'"));
 
         dummyApi("invalidUser", "invalidSecret").dummy();
 
@@ -184,7 +185,7 @@ public class AuthenticationIntegrationTest
     {
         smartlingApi.stubFor(postJson(urlEqualTo("/auth-api/v2/authenticate"))
             .willReturn(error(ResponseCode.GENERAL_ERROR, "[]")
-                .withStatus(500)
+                .withStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)
             )
         );
 
@@ -200,7 +201,7 @@ public class AuthenticationIntegrationTest
     {
         smartlingApi.stubFor(postJson(urlEqualTo("/auth-api/v2/authenticate"))
             .willReturn(error(ResponseCode.MAINTENANCE_MODE_ERROR, "[]")
-                .withStatus(500)
+                .withStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)
             )
         );
 

--- a/smartling-api-commons/src/test/java/com/smartling/api/v2/auth/AuthenticationIntegrationTest.java
+++ b/smartling-api-commons/src/test/java/com/smartling/api/v2/auth/AuthenticationIntegrationTest.java
@@ -14,8 +14,8 @@ import com.smartling.api.v2.client.exception.RestApiRuntimeException;
 import com.smartling.api.v2.client.exception.server.MaintanenceModeErrorException;
 import com.smartling.api.v2.client.exception.server.ServerApiException;
 import com.smartling.api.v2.response.ResponseCode;
+import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
-import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -224,7 +224,7 @@ public class AuthenticationIntegrationTest
         smartlingApi.verify(0, getRequestedFor(urlEqualTo(DUMMY_API)));
     }
 
-    public class ExceptionMatcher implements Matcher<RestApiRuntimeException>
+    public class ExceptionMatcher extends BaseMatcher<RestApiRuntimeException>
     {
         private final int status;
         private final String message;
@@ -242,18 +242,6 @@ public class AuthenticationIntegrationTest
             RestApiRuntimeException ex = (RestApiRuntimeException)o;
 
             return ex.getStatus() == this.status && ex.getMessage().equals(this.message);
-        }
-
-        @Override
-        public void describeMismatch(Object o, Description description)
-        {
-
-        }
-
-        @Override
-        public void _dont_implement_Matcher___instead_extend_BaseMatcher_()
-        {
-
         }
 
         @Override

--- a/smartling-api-commons/src/test/java/com/smartling/api/v2/auth/DummyApi.java
+++ b/smartling-api-commons/src/test/java/com/smartling/api/v2/auth/DummyApi.java
@@ -1,0 +1,14 @@
+package com.smartling.api.v2.auth;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+public interface DummyApi
+{
+    String DUMMY_API = "/dummy-api/v2/dummy";
+
+    @GET
+    @Path(DUMMY_API)
+    void dummy();
+
+}

--- a/smartling-api-commons/src/test/java/com/smartling/api/v2/client/exception/DefaultRestApiExceptionMapperTest.java
+++ b/smartling-api-commons/src/test/java/com/smartling/api/v2/client/exception/DefaultRestApiExceptionMapperTest.java
@@ -1,6 +1,7 @@
 package com.smartling.api.v2.client.exception;
 
 import com.smartling.api.v2.client.exception.client.ClientApiException;
+import com.smartling.api.v2.client.exception.client.NotFoundErrorException;
 import com.smartling.api.v2.client.exception.client.ValidationErrorException;
 import com.smartling.api.v2.client.exception.server.ServerApiException;
 import com.smartling.api.v2.response.ErrorResponse;
@@ -12,6 +13,8 @@ import org.mockito.MockitoAnnotations;
 
 import javax.ws.rs.core.Response;
 
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -78,6 +81,16 @@ public class DefaultRestApiExceptionMapperTest
         when(response.getStatus()).thenReturn(640);
 
         RestApiRuntimeException ex = exceptionMapper.toException(throwable, response, errorResponse);
-        assertTrue(ex instanceof RestApiRuntimeException);
+        assertEquals(ex.getClass(), RestApiRuntimeException.class);
+    }
+
+    @Test
+    public void testCreateNotFoundByResponseCode()
+    {
+        when(response.getStatus()).thenReturn(SC_NOT_FOUND);
+        when(errorResponse.getCode()).thenReturn(ResponseCode.VALIDATION_ERROR);
+
+        RestApiRuntimeException ex = exceptionMapper.toException(throwable, response, errorResponse);
+        assertTrue(ex instanceof NotFoundErrorException);
     }
 }

--- a/smartling-api-commons/src/test/java/com/smartling/api/v2/client/exception/DefaultRestApiExceptionMapperTest.java
+++ b/smartling-api-commons/src/test/java/com/smartling/api/v2/client/exception/DefaultRestApiExceptionMapperTest.java
@@ -6,6 +6,7 @@ import com.smartling.api.v2.client.exception.client.ValidationErrorException;
 import com.smartling.api.v2.client.exception.server.ServerApiException;
 import com.smartling.api.v2.response.ErrorResponse;
 import com.smartling.api.v2.response.ResponseCode;
+import org.apache.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -13,7 +14,6 @@ import org.mockito.MockitoAnnotations;
 
 import javax.ws.rs.core.Response;
 
-import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -59,7 +59,7 @@ public class DefaultRestApiExceptionMapperTest
     @Test
     public void testCreateAuthenticationErrorException() throws Exception
     {
-        when(response.getStatus()).thenReturn(401);
+        when(response.getStatus()).thenReturn(HttpStatus.SC_UNAUTHORIZED);
         when(errorResponse.getCode()).thenReturn(ResponseCode.VALIDATION_ERROR);
 
         RestApiRuntimeException ex = exceptionMapper.toException(throwable, response, errorResponse);
@@ -87,7 +87,7 @@ public class DefaultRestApiExceptionMapperTest
     @Test
     public void testCreateNotFoundByResponseCode()
     {
-        when(response.getStatus()).thenReturn(SC_NOT_FOUND);
+        when(response.getStatus()).thenReturn(HttpStatus.SC_NOT_FOUND);
         when(errorResponse.getCode()).thenReturn(ResponseCode.VALIDATION_ERROR);
 
         RestApiRuntimeException ex = exceptionMapper.toException(throwable, response, errorResponse);

--- a/smartling-api-commons/src/test/java/com/smartling/api/v2/client/exception/DefaultRestApiExceptionMapperTest.java
+++ b/smartling-api-commons/src/test/java/com/smartling/api/v2/client/exception/DefaultRestApiExceptionMapperTest.java
@@ -54,6 +54,16 @@ public class DefaultRestApiExceptionMapperTest
     }
 
     @Test
+    public void testCreateAuthenticationErrorException() throws Exception
+    {
+        when(response.getStatus()).thenReturn(401);
+        when(errorResponse.getCode()).thenReturn(ResponseCode.VALIDATION_ERROR);
+
+        RestApiRuntimeException ex = exceptionMapper.toException(throwable, response, errorResponse);
+        assertTrue(ex instanceof ClientApiException);
+    }
+
+    @Test
     public void testCreateGenericServerException() throws Exception
     {
         when(response.getStatus()).thenReturn(584);

--- a/smartling-api-commons/src/test/java/com/smartling/api/v2/client/exception/RestApiExceptionHandlerTest.java
+++ b/smartling-api-commons/src/test/java/com/smartling/api/v2/client/exception/RestApiExceptionHandlerTest.java
@@ -1,19 +1,26 @@
 package com.smartling.api.v2.client.exception;
 
-import java.lang.reflect.InvocationTargetException;
-import java.util.Collections;
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
-
 import com.smartling.api.v2.response.ErrorResponse;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 public class RestApiExceptionHandlerTest
@@ -134,5 +141,26 @@ public class RestApiExceptionHandlerTest
 
         final RestApiRuntimeException restApiRuntimeException = handler.createRestApiException(invocationTargetException);
         verify(exceptionMapper, times(1)).toException(eq(ex), eq(response), (ErrorResponse)isNull());
+    }
+
+    @Test
+    public void shouldUnwrapRestApiException()
+    {
+        RestApiRuntimeException original = new RestApiRuntimeException(new Exception());
+        ProcessingException processingException = new ProcessingException(original);
+        final InvocationTargetException invocationTargetException = new InvocationTargetException(processingException);
+
+        final RestApiRuntimeException restApiRuntimeException = handler.createRestApiException(invocationTargetException);
+        assertEquals(restApiRuntimeException, original);
+    }
+
+    @Test
+    public void shouldntUnwrapNullCause()
+    {
+        ProcessingException processingException = new ProcessingException("No Cause");
+        final InvocationTargetException invocationTargetException = new InvocationTargetException(processingException);
+
+        final RestApiRuntimeException restApiRuntimeException = handler.createRestApiException(invocationTargetException);
+        assertEquals(restApiRuntimeException.getCause(), processingException);
     }
 }

--- a/smartling-api-commons/src/test/java/com/smartling/api/v2/wiremock/SmartlingWireMock.java
+++ b/smartling-api-commons/src/test/java/com/smartling/api/v2/wiremock/SmartlingWireMock.java
@@ -1,0 +1,82 @@
+package com.smartling.api.v2.wiremock;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.tomakehurst.wiremock.client.MappingBuilder;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.matching.UrlPattern;
+import com.smartling.api.v2.response.ResponseCode;
+
+import java.io.IOException;
+
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+public class SmartlingWireMock extends WireMock
+{
+    // language=JSON
+    private static final String RESPONSE_TEMPLATE = "{\n" +
+        "  \"response\": {\n" +
+        "    \"code\": \"\"" +
+        "  }\n" +
+        "}";
+
+    private static ObjectMapper mapper = new ObjectMapper();
+
+    private static JsonNode readTree(String object)
+    {
+        try
+        {
+            return mapper.readTree(object);
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException("Can't create json response", e);
+        }
+    }
+
+    private static ObjectNode responseTemplate()
+    {
+        return (ObjectNode) readTree(RESPONSE_TEMPLATE);
+    }
+
+    public static MappingBuilder postJson(UrlPattern urlPattern)
+    {
+        return post(urlPattern)
+            .withHeader("Content-Type", equalTo("application/json"));
+    }
+
+    public static ResponseDefinitionBuilder smartlingResponse(ResponseCode responseCode, String data, String errors)
+    {
+        ObjectNode response = responseTemplate();
+        ((ObjectNode) response.get("response"))
+            .put("code", responseCode.name());
+
+        if (isNotEmpty(data))
+        {
+            ((ObjectNode) response.get("response"))
+                .set("data", readTree(data));
+        }
+
+        if (isNotEmpty(errors))
+        {
+            ((ObjectNode) response.get("response"))
+                .set("errors", readTree(errors));
+        }
+
+        return aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withJsonBody(response);
+    }
+
+    public static ResponseDefinitionBuilder success(String data)
+    {
+        return smartlingResponse(ResponseCode.SUCCESS, data, null);
+    }
+
+    public static ResponseDefinitionBuilder error(ResponseCode responseCode, String errors)
+    {
+        return smartlingResponse(responseCode,null, errors);
+    }
+}

--- a/smartling-files-api/pom.xml
+++ b/smartling-files-api/pom.xml
@@ -32,11 +32,5 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.8.1</version>
         </dependency>
-        <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
-            <version>2.25.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/exceptions/JobBatchesApiExceptionMapper.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/exceptions/JobBatchesApiExceptionMapper.java
@@ -4,11 +4,10 @@ import com.smartling.api.v2.client.exception.DefaultRestApiExceptionMapper;
 import com.smartling.api.v2.client.exception.RestApiRuntimeException;
 import com.smartling.api.v2.response.Error;
 import com.smartling.api.v2.response.ErrorResponse;
+import com.smartling.api.v2.response.ResponseCode;
+import org.apache.http.HttpStatus;
 
 import javax.ws.rs.core.Response;
-
-import static com.smartling.api.v2.response.ResponseCode.GENERAL_ERROR;
-import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 
 public class JobBatchesApiExceptionMapper extends DefaultRestApiExceptionMapper
 {
@@ -20,8 +19,8 @@ public class JobBatchesApiExceptionMapper extends DefaultRestApiExceptionMapper
     {
         if (errorResponse == null
             || errorResponse.getCode() == null
-            || errorResponse.getCode() != GENERAL_ERROR
-            || response.getStatus() != SC_BAD_REQUEST)
+            || errorResponse.getCode() != ResponseCode.GENERAL_ERROR
+            || response.getStatus() != HttpStatus.SC_BAD_REQUEST)
         {
             return super.toException(throwable, response, errorResponse);
         }

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/exceptions/JobBatchesApiExceptionMapper.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/exceptions/JobBatchesApiExceptionMapper.java
@@ -1,4 +1,4 @@
-package com.smartling.api.files.v2.exceptions;
+package com.smartling.api.jobbatches.exceptions;
 
 import com.smartling.api.v2.client.exception.DefaultRestApiExceptionMapper;
 import com.smartling.api.v2.client.exception.RestApiRuntimeException;
@@ -6,13 +6,12 @@ import com.smartling.api.v2.response.Error;
 import com.smartling.api.v2.response.ErrorResponse;
 
 import javax.ws.rs.core.Response;
-import java.util.Objects;
 
-import static com.smartling.api.v2.response.ResponseCode.VALIDATION_ERROR;
+import static com.smartling.api.v2.response.ResponseCode.GENERAL_ERROR;
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 
-public class FilesApiExceptionMapper extends DefaultRestApiExceptionMapper
+public class JobBatchesApiExceptionMapper extends DefaultRestApiExceptionMapper
 {
-    private static final String KEY_FILE_NOT_FOUND = "file.not.found";
     private static final String KEY_PARSE_ERROR = "parse.error";
     private static final String MSG_NO_SOURCE_STRINGS_FOUND_ERROR = "No source strings found;";
 
@@ -21,20 +20,16 @@ public class FilesApiExceptionMapper extends DefaultRestApiExceptionMapper
     {
         if (errorResponse == null
             || errorResponse.getCode() == null
-            || errorResponse.getCode() != VALIDATION_ERROR)
+            || errorResponse.getCode() != GENERAL_ERROR
+            || response.getStatus() != SC_BAD_REQUEST)
         {
             return super.toException(throwable, response, errorResponse);
         }
 
         for (Error error : errorResponse.getErrors())
         {
-            if (Objects.equals(error.getKey(), KEY_FILE_NOT_FOUND))
-            {
-                return new FileNotFoundException(throwable, response, errorResponse);
-            }
-
-            if (Objects.equals(error.getKey(), KEY_PARSE_ERROR)
-                && error.getMessage() != null
+            if (error.getMessage() != null
+                && error.getMessage().contains(KEY_PARSE_ERROR)
                 && error.getMessage().contains(MSG_NO_SOURCE_STRINGS_FOUND_ERROR))
             {
                 return new NoSourceStringsFoundException(throwable, response, errorResponse);

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/exceptions/NoSourceStringsFoundException.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/exceptions/NoSourceStringsFoundException.java
@@ -1,0 +1,14 @@
+package com.smartling.api.jobbatches.exceptions;
+
+import com.smartling.api.v2.client.exception.client.ValidationErrorException;
+import com.smartling.api.v2.response.ErrorResponse;
+
+import javax.ws.rs.core.Response;
+
+public class NoSourceStringsFoundException extends ValidationErrorException
+{
+    public NoSourceStringsFoundException(Throwable cause, Response response, ErrorResponse errorResponse)
+    {
+        super(cause, response, errorResponse);
+    }
+}

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/util/FileUploadProxyUtils.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/util/FileUploadProxyUtils.java
@@ -1,6 +1,6 @@
 package com.smartling.api.jobbatches.util;
 
-import com.smartling.api.v2.client.exception.DefaultRestApiExceptionMapper;
+import com.smartling.api.jobbatches.exceptions.JobBatchesApiExceptionMapper;
 import com.smartling.api.v2.client.exception.RestApiExceptionHandler;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpStatus;
@@ -40,7 +40,7 @@ public class FileUploadProxyUtils
 
     public static Response sendRequest(ResteasyWebTarget client, String path, String projectId, String batchUid, MultipartFormDataOutput output)
     {
-        RestApiExceptionHandler exceptionHandler = new RestApiExceptionHandler(new DefaultRestApiExceptionMapper());
+        RestApiExceptionHandler exceptionHandler = new RestApiExceptionHandler(new JobBatchesApiExceptionMapper());
         try
         {
             Response response = client.path(path)

--- a/smartling-job-batches-api/src/test/java/com/smartling/api/jobbatches/exceptions/JobBatchesApiExceptionMapperTest.java
+++ b/smartling-job-batches-api/src/test/java/com/smartling/api/jobbatches/exceptions/JobBatchesApiExceptionMapperTest.java
@@ -1,0 +1,90 @@
+package com.smartling.api.jobbatches.exceptions;
+
+import com.smartling.api.v2.client.exception.RestApiExceptionMapper;
+import com.smartling.api.v2.client.exception.RestApiRuntimeException;
+import com.smartling.api.v2.response.Error;
+import com.smartling.api.v2.response.ErrorResponse;
+import com.smartling.api.v2.response.ResponseCode;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class JobBatchesApiExceptionMapperTest
+{
+    private RestApiExceptionMapper exceptionMapper;
+    private Response response;
+
+    @Before
+    public void init()
+    {
+        response = mock(Response.class);
+        when(response.getStatus()).thenReturn(SC_BAD_REQUEST);
+        when(response.getStatusInfo()).thenReturn(Response.Status.BAD_REQUEST);
+        exceptionMapper = new JobBatchesApiExceptionMapper();
+    }
+
+    @Test
+    public void shouldCreateNoSourceStringFoundException()
+    {
+        Exception throwable = new Exception();
+        ErrorResponse errorResponse = new ErrorResponse(ResponseCode.GENERAL_ERROR, new Error("parse.error", "parse.error" + "No source strings found;"));
+
+        RestApiRuntimeException exception = exceptionMapper.toException(throwable, response, errorResponse);
+
+        assertTrue(exception instanceof NoSourceStringsFoundException);
+    }
+
+    @Test
+    public void shouldPassNotGeneralErrorException()
+    {
+        Exception throwable = new Exception();
+        ErrorResponse errorResponse = new ErrorResponse(ResponseCode.AUTHENTICATION_ERROR, new Error("parse.error", "parse.error" + "No source strings found;"));
+
+        RestApiRuntimeException exception = exceptionMapper.toException(throwable, response, errorResponse);
+
+        assertFalse(exception instanceof NoSourceStringsFoundException);
+    }
+
+    @Test
+    public void shouldPassNotParseError()
+    {
+        Exception throwable = new Exception();
+        ErrorResponse errorResponse = new ErrorResponse(ResponseCode.GENERAL_ERROR, new Error("any.error", "any.error" + "No source strings found;"));
+
+        RestApiRuntimeException exception = exceptionMapper.toException(throwable, response, errorResponse);
+
+        assertFalse(exception instanceof NoSourceStringsFoundException);
+    }
+
+    @Test
+    public void shouldPassOtherParseErrors()
+    {
+        Exception throwable = new Exception();
+        ErrorResponse errorResponse = new ErrorResponse(ResponseCode.GENERAL_ERROR, new Error("parse.error", "parse.error" + "Some error description;"));
+
+        RestApiRuntimeException exception = exceptionMapper.toException(throwable, response, errorResponse);
+
+        assertFalse(exception instanceof NoSourceStringsFoundException);
+    }
+
+    @Test
+    public void shouldPassAllExceptBadRequestResponse()
+    {
+        when(response.getStatus()).thenReturn(SC_NOT_FOUND);
+        when(response.getStatusInfo()).thenReturn(Response.Status.NOT_FOUND);
+        Exception throwable = new Exception();
+        ErrorResponse errorResponse = new ErrorResponse(ResponseCode.GENERAL_ERROR, new Error("parse.error", "parse.error" + "Some error description;"));
+
+        RestApiRuntimeException exception = exceptionMapper.toException(throwable, response, errorResponse);
+
+        assertFalse(exception instanceof NoSourceStringsFoundException);
+    }
+}

--- a/smartling-job-batches-api/src/test/java/com/smartling/api/jobbatches/exceptions/JobBatchesApiExceptionMapperTest.java
+++ b/smartling-job-batches-api/src/test/java/com/smartling/api/jobbatches/exceptions/JobBatchesApiExceptionMapperTest.java
@@ -5,13 +5,12 @@ import com.smartling.api.v2.client.exception.RestApiRuntimeException;
 import com.smartling.api.v2.response.Error;
 import com.smartling.api.v2.response.ErrorResponse;
 import com.smartling.api.v2.response.ResponseCode;
+import org.apache.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
 
 import javax.ws.rs.core.Response;
 
-import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
-import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -26,7 +25,7 @@ public class JobBatchesApiExceptionMapperTest
     public void init()
     {
         response = mock(Response.class);
-        when(response.getStatus()).thenReturn(SC_BAD_REQUEST);
+        when(response.getStatus()).thenReturn(HttpStatus.SC_BAD_REQUEST);
         when(response.getStatusInfo()).thenReturn(Response.Status.BAD_REQUEST);
         exceptionMapper = new JobBatchesApiExceptionMapper();
     }
@@ -78,7 +77,7 @@ public class JobBatchesApiExceptionMapperTest
     @Test
     public void shouldPassAllExceptBadRequestResponse()
     {
-        when(response.getStatus()).thenReturn(SC_NOT_FOUND);
+        when(response.getStatus()).thenReturn(HttpStatus.SC_NOT_FOUND);
         when(response.getStatusInfo()).thenReturn(Response.Status.NOT_FOUND);
         Exception throwable = new Exception();
         ErrorResponse errorResponse = new ErrorResponse(ResponseCode.GENERAL_ERROR, new Error("parse.error", "parse.error" + "Some error description;"));


### PR DESCRIPTION
Exception handler shouldn't rewrap exceptions thrown by Authentication process

[CON-612](https://bt.smartling.net/browse/CON-612)