### PR TITLE
feat: add fileUri to response for files upload api

### DIFF
--- a/smartling-files-api/src/main/java/com/smartling/api/files/v2/pto/UploadFileResponse.java
+++ b/smartling-files-api/src/main/java/com/smartling/api/files/v2/pto/UploadFileResponse.java
@@ -14,4 +14,5 @@ public class UploadFileResponse implements ResponseData
     private Integer stringCount;
     private Integer wordCount;
     private String message;
+    private String fileUri;
 }

--- a/smartling-files-api/src/test/java/com/smartling/api/files/v2/FilesApiIntTest.java
+++ b/smartling-files-api/src/test/java/com/smartling/api/files/v2/FilesApiIntTest.java
@@ -98,6 +98,7 @@ public class FilesApiIntTest
                     "    \"overWritten\": true,\n" +
                     "    \"stringCount\": 10,\n" +
                     "    \"wordCount\": 3,\n" +
+                    "    \"fileUri\": \"" + FILE_URI + "\",\n" +
                     "    \"message\" : \"uploaded\"\n" +
                     "}")
                 )
@@ -115,6 +116,8 @@ public class FilesApiIntTest
             .directives(directives)
             .localeIdsToAuthorize(Arrays.asList("de-DE", "fr"))
             .build());
+
+        assertEquals(uploadFileResponse.getFileUri(), FILE_URI);
 
         smartlingApi.verify(postRequestedFor(urlEqualTo("/files-api/v2/projects/" + PROJECT_ID + "/file"))
             .withRequestBodyPart(aMultipart()


### PR DESCRIPTION
Add fileUri into response for files upload api. This fileUri will be used in repo connector to uploaded pdf files
[JIRA Ticket](https://bt.smartling.net/browse/REPO-578)





## Squash Commit Guidelines

This is a reminder on how to format your sqaush commit message. Delete from your PR after noting below.

### Message Header

The message header is a single line that contains succinct description of the change containing a type: subject. For example:

`feat: add Foo API`

#### Allowed Types

This describes the kind of change that this commit is providing:

- feat (when adding feature)
- fix (when performing a bug fix)
- docs (when adding or changing documentation)
- refactor (when doing non-breaking code refactoring)
- test (when adding missing tests)
- chore (when performing maintainance)

#### Subject Text

This is a very short description of the change.

- use imperative, present tense: “change” not “changed” nor “changes”
- no dot (.) at the end
