### PR TITLE
fix: Fix RestApiResponse deserialization

### DIFF
--- a/smartling-api-commons/src/main/java/com/smartling/api/v2/response/RestApiResponse.java
+++ b/smartling-api-commons/src/main/java/com/smartling/api/v2/response/RestApiResponse.java
@@ -6,6 +6,10 @@ public class RestApiResponse<T extends ResponseData> implements Serializable
 {
     private Response<T> response;
 
+    public RestApiResponse()
+    {
+    }
+
     public RestApiResponse(Response<T> response)
     {
         this.response = response;
@@ -14,5 +18,10 @@ public class RestApiResponse<T extends ResponseData> implements Serializable
     public Response<T> getResponse()
     {
         return response;
+    }
+
+    public void setResponse(Response<T> response)
+    {
+        this.response = response;
     }
 }


### PR DESCRIPTION
[JIRA Ticket](https://bt.smartling.net/browse/https://bt.smartling.net/browse/CON-946)


#### Subject Text

I tried to use `RestApiResponse` class as a response type for method in our SDK and faced an issue with deserialization:


```
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `com.smartling.api.v2.response.RestApiResponse` (no Creators, like default constructor, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
``` 


I'm adding a default constructor here and a setter to fix deserialization of this class