### PR TITLE
feat: add support of custom ssl context in http clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,21 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <org.powermock.version>2.0.4</org.powermock.version>
         <org.jboss.resteasy.version>3.13.1.Final</org.jboss.resteasy.version>
+        <apache.httpclient.version>4.5.12</apache.httpclient.version>
         <jackson.version>2.12.3</jackson.version>
+        <okhttp.version>4.9.3</okhttp.version>
+        <wiremock.version>2.26.0</wiremock.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${apache.httpclient.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -90,13 +103,13 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
-            <version>3.0.1</version>
+            <version>${okhttp.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
-            <version>2.26.0</version>
+            <version>${wiremock.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/samrtling-api-test-utils/pom.xml
+++ b/samrtling-api-test-utils/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
-            <version>2.26.0</version>
+            <version>${wiremock.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-api-commons/pom.xml
+++ b/smartling-api-commons/pom.xml
@@ -19,5 +19,11 @@
             <version>0.28.1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp-tls</artifactId>
+            <version>${okhttp.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/smartling-api-commons/src/main/java/com/smartling/api/v2/client/HttpClientConfiguration.java
+++ b/smartling-api-commons/src/main/java/com/smartling/api/v2/client/HttpClientConfiguration.java
@@ -1,5 +1,6 @@
 package com.smartling.api.v2.client;
 
+import javax.net.ssl.SSLContext;
 import java.util.Objects;
 
 /**
@@ -42,6 +43,7 @@ public class HttpClientConfiguration
     private Integer proxyPort;
     private String  proxyUser;
     private String  proxyPassword;
+    private SSLContext sslContext;
 
     public int getConnectionRequestTimeout()
     {
@@ -150,6 +152,15 @@ public class HttpClientConfiguration
     public HttpClientConfiguration setProxyPassword(final String proxyPassword)
     {
         this.proxyPassword = Objects.requireNonNull(proxyPassword, "Proxy password must not be empty");
+        return this;
+    }
+
+    public SSLContext getSslContext() {
+        return sslContext;
+    }
+
+    public HttpClientConfiguration setSslContext(SSLContext sslContext) {
+        this.sslContext = sslContext;
         return this;
     }
 }

--- a/smartling-api-commons/src/test/java/com/smartling/api/v2/client/ClientFactoryTest.java
+++ b/smartling-api-commons/src/test/java/com/smartling/api/v2/client/ClientFactoryTest.java
@@ -4,23 +4,36 @@ import com.smartling.api.v2.client.auth.BearerAuthStaticTokenFilter;
 import com.smartling.api.v2.response.EmptyData;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.tls.HandshakeCertificates;
+import okhttp3.tls.HeldCertificate;
 import org.apache.http.HttpStatus;
 import org.apache.http.entity.ContentType;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.client.ClientResponseFilter;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.SocketTimeoutException;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.spy;
@@ -29,7 +42,6 @@ import static org.mockito.Mockito.when;
 public class ClientFactoryTest
 {
     private ClientFactory factory;
-    private String tlsProperty;
     private List<ClientRequestFilter> requestFilters;
     private List<ClientResponseFilter> responseFilters;
 
@@ -75,37 +87,37 @@ public class ClientFactoryTest
     }
 
     @Test(expected = NullPointerException.class)
-    public void testBuildNullRequestFilterList() throws Exception
+    public void testBuildNullRequestFilterList()
     {
         factory.build(null, responseFilters, "foo", Foo.class);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testBuildEmptyRequestFilterList() throws Exception
+    public void testBuildEmptyRequestFilterList()
     {
         factory.build(new LinkedList<ClientRequestFilter>(),  responseFilters, "foo", Foo.class);
     }
 
     @Test(expected = NullPointerException.class)
-    public void testBuildNullResponseFilterList() throws Exception
+    public void testBuildNullResponseFilterList()
     {
         factory.build(requestFilters, null, "foo", Foo.class);
     }
 
     @Test(expected = NullPointerException.class)
-    public void testBuildNullDomain() throws Exception
+    public void testBuildNullDomain()
     {
         factory.build(requestFilters, responseFilters, null, Foo.class);
     }
 
     @Test(expected = NullPointerException.class)
-    public void testBuildNullKlass() throws Exception
+    public void testBuildNullKlass()
     {
         factory.build(requestFilters, responseFilters, "foo", null);
     }
 
     @Test(expected = NullPointerException.class)
-    public void testBuildNullDeserializers() throws Exception
+    public void testBuildNullDeserializers()
     {
         ClientFactory f = spy(factory);
         when(f.getDeserializerMap()).thenReturn(null);
@@ -113,13 +125,13 @@ public class ClientFactoryTest
     }
 
     @Test(expected = NullPointerException.class)
-    public void testBuildNullHttpConfiguration() throws Exception
+    public void testBuildNullHttpConfiguration()
     {
         factory.build(requestFilters, responseFilters, "foo", Foo.class, null, null, null);
     }
 
     @Test
-    public void testBuildList() throws Exception
+    public void testBuildList()
     {
         final Foo foo = factory.build(requestFilters, responseFilters, "foo", Foo.class);
         assertNotNull(foo);
@@ -178,6 +190,41 @@ public class ClientFactoryTest
         }
     }
 
+    @Test
+    public void testCustomSSLContext() throws IOException {
+        String localhost = InetAddress.getByName("localhost").getCanonicalHostName();
+        HeldCertificate localhostCertificate = new HeldCertificate.Builder().addSubjectAlternativeName(localhost).build();
+        HandshakeCertificates serverCertificates = new HandshakeCertificates.Builder().heldCertificate(localhostCertificate).build();
+        HandshakeCertificates clientCertificates = new HandshakeCertificates.Builder().addTrustedCertificate(localhostCertificate.certificate()).build();
+
+        MockWebServer webServer = new MockWebServer();
+        webServer.useHttps(serverCertificates.sslSocketFactory(), false);
+        webServer.start();
+
+        try
+        {
+            String responseBody = "{\"response\":{\"data\":null}}";
+            final MockResponse response = new MockResponse()
+                .setResponseCode(HttpStatus.SC_OK)
+                .setHeader(HttpHeaders.CONTENT_LENGTH, responseBody.length())
+                .setHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON)
+                .setBody(responseBody);
+            webServer.enqueue(response);
+
+            HttpClientConfiguration httpClientConfiguration = new HttpClientConfiguration();
+            httpClientConfiguration.setSslContext(clientCertificates.sslContext());
+
+            Foo foo = factory.build(requestFilters, Collections.<ClientResponseFilter>emptyList(), webServer.url("/").toString(),
+                Foo.class, httpClientConfiguration, null, null);
+
+            foo.getFoo("uid");
+        }
+        finally
+        {
+            webServer.shutdown();
+        }
+    }
+
     @Path("/foo-api/v2")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
@@ -188,12 +235,11 @@ public class ClientFactoryTest
         EmptyData getFoo(@PathParam("accountUid") String accountUid);
     }
 
-    public class Bar implements ClientRequestFilter
+    public static class Bar implements ClientRequestFilter
     {
         @Override
         public void filter(final ClientRequestContext requestContext) throws IOException
         {
-
         }
     }
 }


### PR DESCRIPTION
Add Support of Custom SSL Context in HTTP clients.
[PPGIT-33](https://bt.smartling.net/browse/PPGIT-33),[PPGIT-49](https://bt.smartling.net/browse/PPGIT-49)

PayPal uses customized JVM with custom security providers, their default SSLContext is TLSv1.0 implementation.
In order to force using TLSv1.2 we need the ability to use custom SSL Context during httpClient configuring.

Solution: Added SSL context in HttpClientConfiguration and ClientFactory uses it if it is provided to construct httpClient.