### PR TITLE
DEVORTEX-3626 File API SDK - Wrong parameter names in download multiple file translations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.smartling.api</groupId>
     <artifactId>smartling-sdk-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.31.1-SNAPSHOT</version>
+    <version>DEVORTEX3626-SNAPSHOT</version>
     <name>Smartling API Parent</name>
     <description>Smartling API SDK</description>
     <url>https://api-reference.smartling.com</url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.smartling.api</groupId>
     <artifactId>smartling-sdk-parent</artifactId>
     <packaging>pom</packaging>
-    <version>DEVORTEX3626-SNAPSHOT</version>
+    <version>0.31.2-SNAPSHOT</version>
     <name>Smartling API Parent</name>
     <description>Smartling API SDK</description>
     <url>https://api-reference.smartling.com</url>

--- a/samrtling-api-test-utils/pom.xml
+++ b/samrtling-api-test-utils/pom.xml
@@ -4,13 +4,13 @@
 
     <artifactId>smartling-api-test-utils</artifactId>
     <packaging>jar</packaging>
-    <version>DEVORTEX3626-SNAPSHOT</version>
+    <version>0.31.2-SNAPSHOT</version>
     <name>Smartling API Test Utils</name>
 
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>DEVORTEX3626-SNAPSHOT</version>
+        <version>0.31.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/samrtling-api-test-utils/pom.xml
+++ b/samrtling-api-test-utils/pom.xml
@@ -4,13 +4,13 @@
 
     <artifactId>smartling-api-test-utils</artifactId>
     <packaging>jar</packaging>
-    <version>0.31.1-SNAPSHOT</version>
+    <version>DEVORTEX3626-SNAPSHOT</version>
     <name>Smartling API Test Utils</name>
 
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>0.31.1-SNAPSHOT</version>
+        <version>DEVORTEX3626-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/smartling-api-commons/pom.xml
+++ b/smartling-api-commons/pom.xml
@@ -3,20 +3,20 @@
 
     <artifactId>smartling-api-commons</artifactId>
     <packaging>jar</packaging>
-    <version>DEVORTEX3626-SNAPSHOT</version>
+    <version>0.31.2-SNAPSHOT</version>
     <name>Smartling API Commons</name>
 
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>DEVORTEX3626-SNAPSHOT</version>
+        <version>0.31.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-test-utils</artifactId>
-            <version>DEVORTEX3626-SNAPSHOT</version>
+            <version>0.31.2-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/smartling-api-commons/pom.xml
+++ b/smartling-api-commons/pom.xml
@@ -3,20 +3,20 @@
 
     <artifactId>smartling-api-commons</artifactId>
     <packaging>jar</packaging>
-    <version>0.31.1-SNAPSHOT</version>
+    <version>DEVORTEX3626-SNAPSHOT</version>
     <name>Smartling API Commons</name>
 
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>0.31.1-SNAPSHOT</version>
+        <version>DEVORTEX3626-SNAPSHOT</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-test-utils</artifactId>
-            <version>0.31.1-SNAPSHOT</version>
+            <version>DEVORTEX3626-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/smartling-api-sdk-all/pom.xml
+++ b/smartling-api-sdk-all/pom.xml
@@ -4,62 +4,62 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>0.31.1-SNAPSHOT</version>
+        <version>DEVORTEX3626-SNAPSHOT</version>
     </parent>
     <artifactId>smartling-api-sdk</artifactId>
-    <version>0.31.1-SNAPSHOT</version>
+    <version>DEVORTEX3626-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Smartling API SDK</name>
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-issues-api</artifactId>
-            <version>0.31.1-SNAPSHOT</version>
+            <version>DEVORTEX3626-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-locales-api</artifactId>
-            <version>0.31.1-SNAPSHOT</version>
+            <version>DEVORTEX3626-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-jobs-api</artifactId>
-            <version>0.31.1-SNAPSHOT</version>
+            <version>DEVORTEX3626-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-job-batches-api</artifactId>
-            <version>0.31.1-SNAPSHOT</version>
+            <version>DEVORTEX3626-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-files-api</artifactId>
-            <version>0.31.1-SNAPSHOT</version>
+            <version>DEVORTEX3626-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-projects-api</artifactId>
-            <version>0.31.1-SNAPSHOT</version>
+            <version>DEVORTEX3626-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-strings-api</artifactId>
-            <version>0.31.1-SNAPSHOT</version>
+            <version>DEVORTEX3626-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-contexts-api</artifactId>
-            <version>0.31.1-SNAPSHOT</version>
+            <version>DEVORTEX3626-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-attachments-api</artifactId>
-            <version>0.31.1-SNAPSHOT</version>
+            <version>DEVORTEX3626-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-reports-api</artifactId>
-            <version>0.31.1-SNAPSHOT</version>
+            <version>DEVORTEX3626-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/smartling-api-sdk-all/pom.xml
+++ b/smartling-api-sdk-all/pom.xml
@@ -4,62 +4,62 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>DEVORTEX3626-SNAPSHOT</version>
+        <version>0.31.2-SNAPSHOT</version>
     </parent>
     <artifactId>smartling-api-sdk</artifactId>
-    <version>DEVORTEX3626-SNAPSHOT</version>
+    <version>0.31.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Smartling API SDK</name>
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-issues-api</artifactId>
-            <version>DEVORTEX3626-SNAPSHOT</version>
+            <version>0.31.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-locales-api</artifactId>
-            <version>DEVORTEX3626-SNAPSHOT</version>
+            <version>0.31.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-jobs-api</artifactId>
-            <version>DEVORTEX3626-SNAPSHOT</version>
+            <version>0.31.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-job-batches-api</artifactId>
-            <version>DEVORTEX3626-SNAPSHOT</version>
+            <version>0.31.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-files-api</artifactId>
-            <version>DEVORTEX3626-SNAPSHOT</version>
+            <version>0.31.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-projects-api</artifactId>
-            <version>DEVORTEX3626-SNAPSHOT</version>
+            <version>0.31.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-strings-api</artifactId>
-            <version>DEVORTEX3626-SNAPSHOT</version>
+            <version>0.31.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-contexts-api</artifactId>
-            <version>DEVORTEX3626-SNAPSHOT</version>
+            <version>0.31.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-attachments-api</artifactId>
-            <version>DEVORTEX3626-SNAPSHOT</version>
+            <version>0.31.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-reports-api</artifactId>
-            <version>DEVORTEX3626-SNAPSHOT</version>
+            <version>0.31.2-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/smartling-attachments-api/pom.xml
+++ b/smartling-attachments-api/pom.xml
@@ -4,16 +4,16 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>0.31.1-SNAPSHOT</version>
+        <version>DEVORTEX3626-SNAPSHOT</version>
     </parent>
     <artifactId>smartling-attachments-api</artifactId>
-    <version>0.31.1-SNAPSHOT</version>
+    <version>DEVORTEX3626-SNAPSHOT</version>
     <name>Smartling Attachments API</name>
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>0.31.1-SNAPSHOT</version>
+            <version>DEVORTEX3626-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-attachments-api/pom.xml
+++ b/smartling-attachments-api/pom.xml
@@ -4,16 +4,16 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>DEVORTEX3626-SNAPSHOT</version>
+        <version>0.31.2-SNAPSHOT</version>
     </parent>
     <artifactId>smartling-attachments-api</artifactId>
-    <version>DEVORTEX3626-SNAPSHOT</version>
+    <version>0.31.2-SNAPSHOT</version>
     <name>Smartling Attachments API</name>
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>DEVORTEX3626-SNAPSHOT</version>
+            <version>0.31.2-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-contexts-api/pom.xml
+++ b/smartling-contexts-api/pom.xml
@@ -4,16 +4,16 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>0.31.1-SNAPSHOT</version>
+        <version>DEVORTEX3626-SNAPSHOT</version>
     </parent>
     <artifactId>smartling-contexts-api</artifactId>
-    <version>0.31.1-SNAPSHOT</version>
+    <version>DEVORTEX3626-SNAPSHOT</version>
     <name>Smartling Contexts API</name>
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>0.31.1-SNAPSHOT</version>
+            <version>DEVORTEX3626-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-contexts-api/pom.xml
+++ b/smartling-contexts-api/pom.xml
@@ -4,16 +4,16 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>DEVORTEX3626-SNAPSHOT</version>
+        <version>0.31.2-SNAPSHOT</version>
     </parent>
     <artifactId>smartling-contexts-api</artifactId>
-    <version>DEVORTEX3626-SNAPSHOT</version>
+    <version>0.31.2-SNAPSHOT</version>
     <name>Smartling Contexts API</name>
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>DEVORTEX3626-SNAPSHOT</version>
+            <version>0.31.2-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-files-api/pom.xml
+++ b/smartling-files-api/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>DEVORTEX3626-SNAPSHOT</version>
+        <version>0.31.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>smartling-files-api</artifactId>
-    <version>DEVORTEX3626-SNAPSHOT</version>
+    <version>0.31.2-SNAPSHOT</version>
     <name>Smartling Content Files API</name>
 
     <build>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>DEVORTEX3626-SNAPSHOT</version>
+            <version>0.31.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-test-utils</artifactId>
-            <version>DEVORTEX3626-SNAPSHOT</version>
+            <version>0.31.2-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/smartling-files-api/pom.xml
+++ b/smartling-files-api/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>0.31.1-SNAPSHOT</version>
+        <version>DEVORTEX3626-SNAPSHOT</version>
     </parent>
 
     <artifactId>smartling-files-api</artifactId>
-    <version>0.31.1-SNAPSHOT</version>
+    <version>DEVORTEX3626-SNAPSHOT</version>
     <name>Smartling Content Files API</name>
 
     <build>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>0.31.1-SNAPSHOT</version>
+            <version>DEVORTEX3626-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-test-utils</artifactId>
-            <version>0.31.1-SNAPSHOT</version>
+            <version>DEVORTEX3626-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/smartling-files-api/src/main/java/com/smartling/api/files/v2/pto/DownloadMultipleTranslationsPTO.java
+++ b/smartling-files-api/src/main/java/com/smartling/api/files/v2/pto/DownloadMultipleTranslationsPTO.java
@@ -14,10 +14,10 @@ import java.util.List;
 @Builder
 public class DownloadMultipleTranslationsPTO
 {
-    @QueryParam("fileUris")
+    @QueryParam("fileUris[]")
     private List<String> fileUris;
 
-    @QueryParam("localeIds")
+    @QueryParam("localeIds[]")
     private List<String> localeIds;
 
     @QueryParam("retrievalType")

--- a/smartling-issues-api/pom.xml
+++ b/smartling-issues-api/pom.xml
@@ -5,18 +5,18 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>DEVORTEX3626-SNAPSHOT</version>
+        <version>0.31.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>smartling-issues-api</artifactId>
-    <version>DEVORTEX3626-SNAPSHOT</version>
+    <version>0.31.2-SNAPSHOT</version>
     <name>Smartling Issues API</name>
 
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>DEVORTEX3626-SNAPSHOT</version>
+            <version>0.31.2-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-issues-api/pom.xml
+++ b/smartling-issues-api/pom.xml
@@ -5,18 +5,18 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>0.31.1-SNAPSHOT</version>
+        <version>DEVORTEX3626-SNAPSHOT</version>
     </parent>
 
     <artifactId>smartling-issues-api</artifactId>
-    <version>0.31.1-SNAPSHOT</version>
+    <version>DEVORTEX3626-SNAPSHOT</version>
     <name>Smartling Issues API</name>
 
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>0.31.1-SNAPSHOT</version>
+            <version>DEVORTEX3626-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-job-batches-api/pom.xml
+++ b/smartling-job-batches-api/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>0.31.1-SNAPSHOT</version>
+        <version>DEVORTEX3626-SNAPSHOT</version>
     </parent>
 
     <artifactId>smartling-job-batches-api</artifactId>
-    <version>0.31.1-SNAPSHOT</version>
+    <version>DEVORTEX3626-SNAPSHOT</version>
     <name>Smartling Job Batches API</name>
 
     <build>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>0.31.1-SNAPSHOT</version>
+            <version>DEVORTEX3626-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-job-batches-api/pom.xml
+++ b/smartling-job-batches-api/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>DEVORTEX3626-SNAPSHOT</version>
+        <version>0.31.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>smartling-job-batches-api</artifactId>
-    <version>DEVORTEX3626-SNAPSHOT</version>
+    <version>0.31.2-SNAPSHOT</version>
     <name>Smartling Job Batches API</name>
 
     <build>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>DEVORTEX3626-SNAPSHOT</version>
+            <version>0.31.2-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-jobs-api/pom.xml
+++ b/smartling-jobs-api/pom.xml
@@ -5,18 +5,18 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>DEVORTEX3626-SNAPSHOT</version>
+        <version>0.31.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>smartling-jobs-api</artifactId>
-    <version>DEVORTEX3626-SNAPSHOT</version>
+    <version>0.31.2-SNAPSHOT</version>
     <name>Smartling Jobs API</name>
 
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>DEVORTEX3626-SNAPSHOT</version>
+            <version>0.31.2-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-jobs-api/pom.xml
+++ b/smartling-jobs-api/pom.xml
@@ -5,18 +5,18 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>0.31.1-SNAPSHOT</version>
+        <version>DEVORTEX3626-SNAPSHOT</version>
     </parent>
 
     <artifactId>smartling-jobs-api</artifactId>
-    <version>0.31.1-SNAPSHOT</version>
+    <version>DEVORTEX3626-SNAPSHOT</version>
     <name>Smartling Jobs API</name>
 
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>0.31.1-SNAPSHOT</version>
+            <version>DEVORTEX3626-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-locales-api/pom.xml
+++ b/smartling-locales-api/pom.xml
@@ -4,16 +4,16 @@
   <parent>
     <groupId>com.smartling.api</groupId>
     <artifactId>smartling-sdk-parent</artifactId>
-    <version>DEVORTEX3626-SNAPSHOT</version>
+    <version>0.31.2-SNAPSHOT</version>
   </parent>
   <artifactId>smartling-locales-api</artifactId>
-  <version>DEVORTEX3626-SNAPSHOT</version>
+  <version>0.31.2-SNAPSHOT</version>
   <name>Smartling Locales API</name>
   <dependencies>
     <dependency>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-api-commons</artifactId>
-        <version>DEVORTEX3626-SNAPSHOT</version>
+        <version>0.31.2-SNAPSHOT</version>
     </dependency>
   </dependencies>
 </project>

--- a/smartling-locales-api/pom.xml
+++ b/smartling-locales-api/pom.xml
@@ -4,16 +4,16 @@
   <parent>
     <groupId>com.smartling.api</groupId>
     <artifactId>smartling-sdk-parent</artifactId>
-    <version>0.31.1-SNAPSHOT</version>
+    <version>DEVORTEX3626-SNAPSHOT</version>
   </parent>
   <artifactId>smartling-locales-api</artifactId>
-  <version>0.31.1-SNAPSHOT</version>
+  <version>DEVORTEX3626-SNAPSHOT</version>
   <name>Smartling Locales API</name>
   <dependencies>
     <dependency>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-api-commons</artifactId>
-        <version>0.31.1-SNAPSHOT</version>
+        <version>DEVORTEX3626-SNAPSHOT</version>
     </dependency>
   </dependencies>
 </project>

--- a/smartling-projects-api/pom.xml
+++ b/smartling-projects-api/pom.xml
@@ -4,16 +4,16 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>DEVORTEX3626-SNAPSHOT</version>
+        <version>0.31.2-SNAPSHOT</version>
     </parent>
     <artifactId>smartling-projects-api</artifactId>
-    <version>DEVORTEX3626-SNAPSHOT</version>
+    <version>0.31.2-SNAPSHOT</version>
     <name>Smartling Projects API</name>
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>DEVORTEX3626-SNAPSHOT</version>
+            <version>0.31.2-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-projects-api/pom.xml
+++ b/smartling-projects-api/pom.xml
@@ -4,16 +4,16 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>0.31.1-SNAPSHOT</version>
+        <version>DEVORTEX3626-SNAPSHOT</version>
     </parent>
     <artifactId>smartling-projects-api</artifactId>
-    <version>0.31.1-SNAPSHOT</version>
+    <version>DEVORTEX3626-SNAPSHOT</version>
     <name>Smartling Projects API</name>
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>0.31.1-SNAPSHOT</version>
+            <version>DEVORTEX3626-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-reports-api/pom.xml
+++ b/smartling-reports-api/pom.xml
@@ -4,16 +4,16 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>0.31.1-SNAPSHOT</version>
+        <version>DEVORTEX3626-SNAPSHOT</version>
     </parent>
     <artifactId>smartling-reports-api</artifactId>
-    <version>0.31.1-SNAPSHOT</version>
+    <version>DEVORTEX3626-SNAPSHOT</version>
     <name>Smartling Reports API</name>
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>0.31.1-SNAPSHOT</version>
+            <version>DEVORTEX3626-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-reports-api/pom.xml
+++ b/smartling-reports-api/pom.xml
@@ -4,16 +4,16 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>DEVORTEX3626-SNAPSHOT</version>
+        <version>0.31.2-SNAPSHOT</version>
     </parent>
     <artifactId>smartling-reports-api</artifactId>
-    <version>DEVORTEX3626-SNAPSHOT</version>
+    <version>0.31.2-SNAPSHOT</version>
     <name>Smartling Reports API</name>
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>DEVORTEX3626-SNAPSHOT</version>
+            <version>0.31.2-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-strings-api/pom.xml
+++ b/smartling-strings-api/pom.xml
@@ -4,16 +4,16 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>DEVORTEX3626-SNAPSHOT</version>
+        <version>0.31.2-SNAPSHOT</version>
     </parent>
     <artifactId>smartling-strings-api</artifactId>
-    <version>DEVORTEX3626-SNAPSHOT</version>
+    <version>0.31.2-SNAPSHOT</version>
     <name>Smartling Strings API</name>
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>DEVORTEX3626-SNAPSHOT</version>
+            <version>0.31.2-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-strings-api/pom.xml
+++ b/smartling-strings-api/pom.xml
@@ -4,16 +4,16 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>0.31.1-SNAPSHOT</version>
+        <version>DEVORTEX3626-SNAPSHOT</version>
     </parent>
     <artifactId>smartling-strings-api</artifactId>
-    <version>0.31.1-SNAPSHOT</version>
+    <version>DEVORTEX3626-SNAPSHOT</version>
     <name>Smartling Strings API</name>
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>0.31.1-SNAPSHOT</version>
+            <version>DEVORTEX3626-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
`FilesApi.downloadMultipleFileTranslations(...)` uses wrong parameter names: `fileUris & localeIds` instead of `fileUris[] & localeIds[]`.

[API Documentation](https://api-reference.smartling.com/\#tag/Files/operation/downloadMultipleTranslatedFiles)

[JIRA Ticket](https://bt.smartling.net/browse/DEVORTEX-3626)
