### PR TITLE
fix: fix parameter names in download multiple file translations

### DIFF
--- a/smartling-files-api/src/main/java/com/smartling/api/files/v2/pto/DownloadMultipleTranslationsPTO.java
+++ b/smartling-files-api/src/main/java/com/smartling/api/files/v2/pto/DownloadMultipleTranslationsPTO.java
@@ -14,10 +14,10 @@ import java.util.List;
 @Builder
 public class DownloadMultipleTranslationsPTO
 {
-    @QueryParam("fileUris")
+    @QueryParam("fileUris[]")
     private List<String> fileUris;
 
-    @QueryParam("localeIds")
+    @QueryParam("localeIds[]")
     private List<String> localeIds;
 
     @QueryParam("retrievalType")


### PR DESCRIPTION
`FilesApi.downloadMultipleFileTranslations(...)` uses wrong parameter names: `fileUris & localeIds` instead of `fileUris[] & localeIds[]`.

[API Documentation](https://api-reference.smartling.com/#tag/Files/operation/downloadMultipleTranslatedFiles)

[Jira Ticket](https://bt.smartling.net/browse/DEVORTEX-3626)

