### PR TITLE
fix: properties not found warnings 

### DIFF
--- a/smartling-api-commons/pom.xml
+++ b/smartling-api-commons/pom.xml
@@ -12,6 +12,15 @@
         <version>1.8.3-SNAPSHOT</version>
     </parent>
 
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>

--- a/smartling-api-commons/src/main/resources/com/smartling/api/v2/authentication/sdk-project.properties
+++ b/smartling-api-commons/src/main/resources/com/smartling/api/v2/authentication/sdk-project.properties
@@ -1,0 +1,2 @@
+artifactId=${project.artifactId}
+version=${project.version}

--- a/smartling-api-commons/src/test/java/com/smartling/api/v2/auth/AuthenticationIntegrationTest.java
+++ b/smartling-api-commons/src/test/java/com/smartling/api/v2/auth/AuthenticationIntegrationTest.java
@@ -16,6 +16,7 @@ import com.smartling.api.v2.client.exception.server.MaintanenceModeErrorExceptio
 import com.smartling.api.v2.client.exception.server.ServerApiException;
 import com.smartling.api.v2.response.ResponseCode;
 import com.smartling.api.v2.tests.wiremock.SmartlingWireMock;
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -103,6 +104,8 @@ public class AuthenticationIntegrationTest
 
         smartlingApi.verify(getRequestedFor(urlEqualTo(DUMMY_API))
             .withHeader("Authorization", equalTo("Bearer accessTokenValue")));
+        smartlingApi.verify(postRequestedFor(urlEqualTo("/auth-api/v2/authenticate"))
+            .withHeader(HttpHeaders.USER_AGENT, matching("smartling-api-commons-java/.*")));
     }
 
     @Test
@@ -193,6 +196,11 @@ public class AuthenticationIntegrationTest
 
         smartlingApi.verify(1, getRequestedFor(urlEqualTo(DUMMY_API))
             .withHeader("Authorization", equalTo("Bearer refreshedAccessTokenValue")));
+
+        smartlingApi.verify(postRequestedFor(urlEqualTo("/auth-api/v2/authenticate"))
+            .withHeader(HttpHeaders.USER_AGENT, matching("smartling-api-commons-java/.*")));
+        smartlingApi.verify(postRequestedFor(urlEqualTo("/auth-api/v2/authenticate/refresh"))
+            .withHeader(HttpHeaders.USER_AGENT, matching("smartling-api-commons-java/.*")));
     }
 
     @Test

--- a/smartling-file-translations-api/src/main/resources/com/smartling/api/filetranslations/v2/sdk-project.properties
+++ b/smartling-file-translations-api/src/main/resources/com/smartling/api/filetranslations/v2/sdk-project.properties
@@ -1,0 +1,2 @@
+artifactId=${project.artifactId}
+version=${project.version}

--- a/smartling-file-translations-api/src/test/java/com/smartling/api/filetranslations/v2/FileTranslationsApiTest.java
+++ b/smartling-file-translations-api/src/test/java/com/smartling/api/filetranslations/v2/FileTranslationsApiTest.java
@@ -51,6 +51,7 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -305,6 +306,7 @@ public class FileTranslationsApiTest
         assertEquals(httpMethod, request.getMethod());
         assertEquals("Bearer authToken", request.getHeader(HttpHeaders.AUTHORIZATION));
         assertEquals(request.getPath(), path);
+        assertThat(request.getHeader(HttpHeaders.USER_AGENT), startsWith("smartling-file-translations-api-java/"));
         return request;
     }
 


### PR DESCRIPTION
warnings like: Could not initialize LibNameVersionHolder from properties: Properties file not found filename=sdk-project.properties