### PR TITLE
feat: add support for multipart downloading of a translated file to Files API

### DIFF
--- a/smartling-files-api/src/main/java/com/smartling/api/files/v2/FilesApi.java
+++ b/smartling-files-api/src/main/java/com/smartling/api/files/v2/FilesApi.java
@@ -20,6 +20,7 @@ import com.smartling.api.files.v2.pto.UploadFileResponse;
 import com.smartling.api.v2.client.exception.server.DetailedErrorMessage;
 import com.smartling.api.v2.response.EmptyData;
 import com.smartling.api.v2.response.ListResponse;
+import com.smartling.api.files.v2.resteasy.ext.TranslatedFileMultipart;
 import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
 
 import javax.ws.rs.BeanParam;
@@ -36,6 +37,7 @@ import java.io.InputStream;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.MULTIPART_FORM_DATA;
 import static javax.ws.rs.core.MediaType.WILDCARD;
+import static org.jboss.resteasy.plugins.providers.multipart.MultipartConstants.MULTIPART_MIXED;
 
 @Produces(APPLICATION_JSON)
 @Consumes(APPLICATION_JSON)
@@ -65,6 +67,11 @@ public interface FilesApi
     @Path("/projects/{projectId}/locales/{localeId}/file")
     @Produces(WILDCARD)
     InputStream downloadTranslatedFile(@PathParam("projectId") String projectId, @PathParam("localeId") String localeId, @BeanParam DownloadTranslationPTO downloadTranslationPTO);
+
+    @GET
+    @Path("/projects/{projectId}/locales/{localeId}/file")
+    @Produces(MULTIPART_MIXED)
+    TranslatedFileMultipart downloadTranslatedFileMultipart(@PathParam("projectId") String projectId, @PathParam("localeId") String localeId, @BeanParam DownloadTranslationPTO downloadTranslationPTO);
 
     @GET
     @Path("/projects/{projectId}/locales/all/file/zip")

--- a/smartling-files-api/src/main/java/com/smartling/api/files/v2/FilesApiFactory.java
+++ b/smartling-files-api/src/main/java/com/smartling/api/files/v2/FilesApiFactory.java
@@ -7,7 +7,7 @@ import com.smartling.api.v2.client.ClientConfiguration;
 import com.smartling.api.v2.client.ClientFactory;
 import com.smartling.api.v2.client.DefaultClientConfiguration;
 import com.smartling.api.v2.client.auth.AuthorizationRequestFilter;
-import org.jboss.resteasy.client.jaxrs.internal.LocalResteasyProviderFactory;
+import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
 public class FilesApiFactory extends AbstractApiFactory<FilesApi>
@@ -33,7 +33,7 @@ public class FilesApiFactory extends AbstractApiFactory<FilesApi>
     {
         ResteasyProviderFactory resteasyProviderFactory = config.getResteasyProviderFactory();
         if (null == resteasyProviderFactory)
-            resteasyProviderFactory = new LocalResteasyProviderFactory(ResteasyProviderFactory.getInstance());
+            resteasyProviderFactory = new ResteasyClientBuilderImpl().getProviderFactory();
         resteasyProviderFactory.register(TranslatedFileMultipartReader.class);
 
         ClientConfiguration filesConfig = DefaultClientConfiguration.builder()

--- a/smartling-files-api/src/main/java/com/smartling/api/files/v2/FilesApiFactory.java
+++ b/smartling-files-api/src/main/java/com/smartling/api/files/v2/FilesApiFactory.java
@@ -1,11 +1,14 @@
 package com.smartling.api.files.v2;
 
 import com.smartling.api.files.v2.exceptions.FilesApiExceptionMapper;
+import com.smartling.api.files.v2.resteasy.ext.TranslatedFileMultipartReader;
 import com.smartling.api.v2.client.AbstractApiFactory;
 import com.smartling.api.v2.client.ClientConfiguration;
 import com.smartling.api.v2.client.ClientFactory;
 import com.smartling.api.v2.client.DefaultClientConfiguration;
 import com.smartling.api.v2.client.auth.AuthorizationRequestFilter;
+import org.jboss.resteasy.client.jaxrs.internal.LocalResteasyProviderFactory;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
 public class FilesApiFactory extends AbstractApiFactory<FilesApi>
 {
@@ -28,13 +31,18 @@ public class FilesApiFactory extends AbstractApiFactory<FilesApi>
     @Override
     public FilesApi buildApi(final AuthorizationRequestFilter authFilter, ClientConfiguration config)
     {
+        ResteasyProviderFactory resteasyProviderFactory = config.getResteasyProviderFactory();
+        if (null == resteasyProviderFactory)
+            resteasyProviderFactory = new LocalResteasyProviderFactory(ResteasyProviderFactory.getInstance());
+        resteasyProviderFactory.register(TranslatedFileMultipartReader.class);
+
         ClientConfiguration filesConfig = DefaultClientConfiguration.builder()
             .baseUrl(config.getBaseUrl())
             .clientRequestFilters(config.getClientRequestFilters())
             .clientResponseFilters(config.getClientResponseFilters())
             .libNameVersionHolder(config.getLibNameVersionHolder())
             .httpClientConfiguration(config.getHttpClientConfiguration())
-            .resteasyProviderFactory(config.getResteasyProviderFactory())
+            .resteasyProviderFactory(resteasyProviderFactory)
             .exceptionMapper(new FilesApiExceptionMapper())
             .build();
 

--- a/smartling-files-api/src/main/java/com/smartling/api/files/v2/resteasy/ext/TranslatedFileMetadata.java
+++ b/smartling-files-api/src/main/java/com/smartling/api/files/v2/resteasy/ext/TranslatedFileMetadata.java
@@ -1,0 +1,10 @@
+package com.smartling.api.files.v2.resteasy.ext;
+
+import lombok.Data;
+
+@Data
+public class TranslatedFileMetadata
+{
+    // Now we leave the class empty and will use it as an end marker for the file body only.
+    // In the future we will expand this object with additional metadata associated with the downloaded file.
+}

--- a/smartling-files-api/src/main/java/com/smartling/api/files/v2/resteasy/ext/TranslatedFileMultipart.java
+++ b/smartling-files-api/src/main/java/com/smartling/api/files/v2/resteasy/ext/TranslatedFileMultipart.java
@@ -22,8 +22,7 @@ public class TranslatedFileMultipart
 
     public void close()
     {
-        if (null != fileBody)
-            IOUtils.closeQuietly(fileBody);
+        IOUtils.closeQuietly(fileBody);
         if (null != multipartInput)
             multipartInput.close();
     }

--- a/smartling-files-api/src/main/java/com/smartling/api/files/v2/resteasy/ext/TranslatedFileMultipart.java
+++ b/smartling-files-api/src/main/java/com/smartling/api/files/v2/resteasy/ext/TranslatedFileMultipart.java
@@ -1,6 +1,7 @@
 package com.smartling.api.files.v2.resteasy.ext;
 
 import lombok.Getter;
+import org.apache.commons.io.IOUtils;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartInput;
 
 import javax.ws.rs.core.MediaType;
@@ -19,8 +20,10 @@ public class TranslatedFileMultipart
     TranslatedFileMetadata translatedFileMetadata;
     MultipartInput multipartInput;
 
-    void close()
+    public void close()
     {
+        if (null != fileBody)
+            IOUtils.closeQuietly(fileBody);
         if (null != multipartInput)
             multipartInput.close();
     }

--- a/smartling-files-api/src/main/java/com/smartling/api/files/v2/resteasy/ext/TranslatedFileMultipart.java
+++ b/smartling-files-api/src/main/java/com/smartling/api/files/v2/resteasy/ext/TranslatedFileMultipart.java
@@ -1,0 +1,27 @@
+package com.smartling.api.files.v2.resteasy.ext;
+
+import lombok.Getter;
+import org.jboss.resteasy.plugins.providers.multipart.MultipartInput;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import java.io.InputStream;
+
+public class TranslatedFileMultipart
+{
+    @Getter
+    InputStream fileBody;
+    @Getter
+    MultivaluedMap<String, String> fileHeaders;
+    @Getter
+    MediaType fileMediaType;
+    @Getter
+    TranslatedFileMetadata translatedFileMetadata;
+    MultipartInput multipartInput;
+
+    void close()
+    {
+        if (null != multipartInput)
+            multipartInput.close();
+    }
+}

--- a/smartling-files-api/src/main/java/com/smartling/api/files/v2/resteasy/ext/TranslatedFileMultipartReader.java
+++ b/smartling-files-api/src/main/java/com/smartling/api/files/v2/resteasy/ext/TranslatedFileMultipartReader.java
@@ -1,0 +1,72 @@
+package com.smartling.api.files.v2.resteasy.ext;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jboss.resteasy.plugins.providers.multipart.InputPart;
+import org.jboss.resteasy.plugins.providers.multipart.MultipartInputImpl;
+import org.jboss.resteasy.plugins.providers.multipart.i18n.Messages;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.Provider;
+import javax.ws.rs.ext.Providers;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import static java.lang.String.format;
+import static org.jboss.resteasy.plugins.providers.multipart.MultipartConstants.MULTIPART_MIXED;
+
+@Provider
+@Consumes(MULTIPART_MIXED)
+public class TranslatedFileMultipartReader implements MessageBodyReader<TranslatedFileMultipart>
+{
+    private static final String BOUNDARY_PARAMETER = "boundary";
+
+    protected @Context Providers workers;
+
+    @Override
+    public boolean isReadable(Class<?> clazz, Type type, Annotation[] annotations, MediaType mediaType)
+    {
+        return type.equals(TranslatedFileMultipart.class);
+    }
+
+    @Override
+    public TranslatedFileMultipart readFrom(Class<TranslatedFileMultipart> clazz, Type type, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> multivaluedMap, InputStream inputStream) throws IOException, WebApplicationException
+    {
+        final String boundary = mediaType.getParameters().get(BOUNDARY_PARAMETER);
+        if (null == boundary)
+            throw new IOException(Messages.MESSAGES.unableToGetBoundary());
+        final MultipartInputImpl multipartInput = new MultipartInputImpl(mediaType, workers);
+        multipartInput.parse(inputStream);
+
+        if (multipartInput.getParts().size() != 2)
+            throw new IOException(format("The response contains unexpected number of parts (%d). Two parts are expected. The first one is file's body, the second one is metadata object.", multipartInput.getParts().size()));
+
+        final InputPart filePart = multipartInput.getParts().get(0);
+        final InputPart metadataPart = multipartInput.getParts().get(1);
+
+        final TranslatedFileMultipart translatedFileMultipart = new TranslatedFileMultipart();
+        translatedFileMultipart.multipartInput = multipartInput;
+        translatedFileMultipart.fileBody = filePart.getBody(InputStream.class, null);
+        translatedFileMultipart.fileHeaders = filePart.getHeaders();
+        translatedFileMultipart.fileMediaType = filePart.getMediaType();
+
+        final MediaType metadataPartMediaType = metadataPart.getMediaType();
+        if (null == metadataPartMediaType)
+            throw new IOException("Missing content type of metadata part.");
+
+        if (!StringUtils.equalsIgnoreCase(MediaType.APPLICATION_JSON_TYPE.getType(), metadataPartMediaType.getType()) || !StringUtils.equalsIgnoreCase(MediaType.APPLICATION_JSON_TYPE.getSubtype(), metadataPartMediaType.getSubtype()))
+            throw new IOException(format("Unexpected content type of metadata part (%s). Expected (%s) metadata part.", metadataPart.getMediaType(), MediaType.APPLICATION_JSON_TYPE));
+
+        translatedFileMultipart.translatedFileMetadata = metadataPart.getBody(TranslatedFileMetadata.class, TranslatedFileMetadata.class);
+        if (null == translatedFileMultipart.translatedFileMetadata)
+            throw new IOException("Cannot construct metadata json object.");
+
+        return translatedFileMultipart;
+    }
+}

--- a/smartling-files-api/src/test/java/com/smartling/api/files/v2/resteasy/ext/TranslatedFileMultipartReaderTest.java
+++ b/smartling-files-api/src/test/java/com/smartling/api/files/v2/resteasy/ext/TranslatedFileMultipartReaderTest.java
@@ -1,0 +1,304 @@
+package com.smartling.api.files.v2.resteasy.ext;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.Providers;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import static java.util.Collections.singletonList;
+import static org.jboss.resteasy.plugins.providers.multipart.MultipartConstants.MULTIPART_MIXED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class TranslatedFileMultipartReaderTest
+{
+    @InjectMocks
+    private TranslatedFileMultipartReader translatedFileMultipartReader = new TranslatedFileMultipartReader();
+
+    @Mock
+    protected Providers workers;
+
+    @Before
+    public void setUp()
+    {
+        initMocks(this);
+    }
+
+    @Test
+    public void testIsReadable()
+    {
+        assertTrue(translatedFileMultipartReader.isReadable(TranslatedFileMultipart.class, TranslatedFileMultipart.class, null, null));
+        assertFalse(translatedFileMultipartReader.isReadable(TranslatedFileMultipart.class, Integer.class, null, null));
+    }
+
+    @Test
+    public void testReadFromWhenSuccess() throws IOException
+    {
+        final String boundary = UUID.randomUUID().toString();
+        final String responseBody = "--" + boundary + "\r\n"
+            + "Content-Type: application/octet-stream; charset=UTF-8\r\n"
+            + "Content-Disposition: attachment; filename=\"myfile.properties\";\r\n"
+            + "\r\n"
+            + "key1=value1\nkey2=value2\r\n"
+            + "--" + boundary + "\r\n"
+            + "Content-Type: application/json; charset=UTF-8\r\n"
+            + "\r\n"
+            + "{\"key\":\"value\"}\r\n"
+            + "--" + boundary + "--";
+
+        final MediaType fileMediaType = MediaType.valueOf("application/octet-stream; charset=UTF-8");
+
+        final MessageBodyReader<InputStream> inputStreamReader = mock(MessageBodyReader.class);
+        when(inputStreamReader.isReadable(InputStream.class, null, null, fileMediaType)).thenReturn(true);
+        when(inputStreamReader.readFrom(any(), any(), any(), any(), any(), any())).thenReturn(new ByteArrayInputStream("key1=value1\nkey2=value2".getBytes()));
+        when(workers.getMessageBodyReader(InputStream.class, null, new Annotation[] {}, fileMediaType)).thenReturn(inputStreamReader);
+
+        final MediaType metadataMediaType = MediaType.valueOf("application/json; charset=UTF-8");
+
+        final TranslatedFileMetadata translatedFileMetadata = mock(TranslatedFileMetadata.class);
+        final MessageBodyReader<TranslatedFileMetadata> metadataReader = mock(MessageBodyReader.class);
+        when(metadataReader.isReadable(TranslatedFileMetadata.class, TranslatedFileMetadata.class, null, metadataMediaType)).thenReturn(true);
+        when(metadataReader.readFrom(any(), any(), any(), any(), any(), any())).thenReturn(translatedFileMetadata);
+        when(workers.getMessageBodyReader(TranslatedFileMetadata.class, TranslatedFileMetadata.class, new Annotation[] {}, metadataMediaType)).thenReturn(metadataReader);
+
+        final TranslatedFileMultipart translatedFileMultipart = translatedFileMultipartReader.readFrom(
+            TranslatedFileMultipart.class,
+            TranslatedFileMultipart.class,
+            null,
+            MediaType.valueOf(MULTIPART_MIXED + "; boundary=" + boundary),
+            null,
+            new ByteArrayInputStream(responseBody.getBytes())
+        );
+        assertNotNull(translatedFileMultipart);
+        assertSame(translatedFileMetadata, translatedFileMultipart.getTranslatedFileMetadata());
+
+        final MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.put(HttpHeaders.CONTENT_TYPE, singletonList("application/octet-stream; charset=UTF-8"));
+        headers.put(HttpHeaders.CONTENT_DISPOSITION, singletonList("attachment; filename=\"myfile.properties\";"));
+        assertEquals(headers, translatedFileMultipart.getFileHeaders());
+        assertEquals(MediaType.APPLICATION_OCTET_STREAM_TYPE.withCharset("UTF-8"), translatedFileMultipart.getFileMediaType());
+        final InputStream inputStream = translatedFileMultipart.getFileBody();
+        final String fileString = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+        assertEquals("key1=value1\nkey2=value2", fileString);
+    }
+
+    @Test(expected = IOException.class)
+    public void testReadFromWhenFailedDueToBoundaryAbsence() throws IOException
+    {
+        final String boundary = UUID.randomUUID().toString();
+        final String responseBody = "--" + boundary + "\r\n"
+            + "Content-Type: application/octet-stream; charset=UTF-8\r\n"
+            + "Content-Disposition: attachment; filename=\"myfile.properties\";\r\n"
+            + "\r\n"
+            + "key1=value1\nkey2=value2\r\n"
+            + "--" + boundary + "\r\n"
+            + "Content-Type: application/json; charset=UTF-8\r\n"
+            + "\r\n"
+            + "{\"key\":\"value\"}\r\n"
+            + "--" + boundary + "--";
+
+        final MediaType fileMediaType = MediaType.valueOf("application/octet-stream; charset=UTF-8");
+
+        final MessageBodyReader<InputStream> inputStreamReader = mock(MessageBodyReader.class);
+        when(inputStreamReader.isReadable(InputStream.class, null, null, fileMediaType)).thenReturn(true);
+        when(inputStreamReader.readFrom(any(), any(), any(), any(), any(), any())).thenReturn(new ByteArrayInputStream("key1=value1\nkey2=value2".getBytes()));
+        when(workers.getMessageBodyReader(InputStream.class, null, new Annotation[] {}, fileMediaType)).thenReturn(inputStreamReader);
+
+        final MediaType metadataMediaType = MediaType.valueOf("application/json; charset=UTF-8");
+
+        final TranslatedFileMetadata translatedFileMetadata = mock(TranslatedFileMetadata.class);
+        final MessageBodyReader<TranslatedFileMetadata> metadataReader = mock(MessageBodyReader.class);
+        when(metadataReader.isReadable(TranslatedFileMetadata.class, TranslatedFileMetadata.class, null, metadataMediaType)).thenReturn(true);
+        when(metadataReader.readFrom(any(), any(), any(), any(), any(), any())).thenReturn(translatedFileMetadata);
+        when(workers.getMessageBodyReader(TranslatedFileMetadata.class, TranslatedFileMetadata.class, new Annotation[] {}, metadataMediaType)).thenReturn(metadataReader);
+
+        translatedFileMultipartReader.readFrom(
+            TranslatedFileMultipart.class,
+            TranslatedFileMultipart.class,
+            null,
+            MediaType.valueOf(MULTIPART_MIXED),
+            null,
+            new ByteArrayInputStream(responseBody.getBytes())
+        );
+    }
+
+    @Test(expected = IOException.class)
+    public void testReadFromWhenFailedDueToBigNumberOfParts() throws IOException
+    {
+        final String boundary = UUID.randomUUID().toString();
+        final String responseBody = "--" + boundary + "\r\n"
+            + "Content-Type: application/octet-stream; charset=UTF-8\r\n"
+            + "Content-Disposition: attachment; filename=\"myfile.properties\";\r\n"
+            + "\r\n"
+            + "key1=value1\nkey2=value2\r\n"
+            + "--" + boundary + "\r\n"
+            + "Content-Type: application/json; charset=UTF-8\r\n"
+            + "\r\n"
+            + "{\"key\":\"value\"}\r\n"
+            + "--" + boundary + "\r\n"
+            + "Content-Type: application/json; charset=UTF-8\r\n"
+            + "\r\n"
+            + "{\"key\":\"value\"}\r\n"
+            + "--" + boundary + "--";
+
+        final MediaType fileMediaType = MediaType.valueOf("application/octet-stream; charset=UTF-8");
+
+        final MessageBodyReader<InputStream> inputStreamReader = mock(MessageBodyReader.class);
+        when(inputStreamReader.isReadable(InputStream.class, null, null, fileMediaType)).thenReturn(true);
+        when(inputStreamReader.readFrom(any(), any(), any(), any(), any(), any())).thenReturn(new ByteArrayInputStream("key1=value1\nkey2=value2".getBytes()));
+        when(workers.getMessageBodyReader(InputStream.class, null, new Annotation[] {}, fileMediaType)).thenReturn(inputStreamReader);
+
+        final MediaType metadataMediaType = MediaType.valueOf("application/json; charset=UTF-8");
+
+        final TranslatedFileMetadata translatedFileMetadata = mock(TranslatedFileMetadata.class);
+        final MessageBodyReader<TranslatedFileMetadata> metadataReader = mock(MessageBodyReader.class);
+        when(metadataReader.isReadable(TranslatedFileMetadata.class, TranslatedFileMetadata.class, null, metadataMediaType)).thenReturn(true);
+        when(metadataReader.readFrom(any(), any(), any(), any(), any(), any())).thenReturn(translatedFileMetadata);
+        when(workers.getMessageBodyReader(TranslatedFileMetadata.class, TranslatedFileMetadata.class, new Annotation[] {}, metadataMediaType)).thenReturn(metadataReader);
+
+        translatedFileMultipartReader.readFrom(
+            TranslatedFileMultipart.class,
+            TranslatedFileMultipart.class,
+            null,
+            MediaType.valueOf(MULTIPART_MIXED + "; boundary=" + boundary),
+            null,
+            new ByteArrayInputStream(responseBody.getBytes())
+        );
+    }
+
+    @Test(expected = IOException.class)
+    public void testReadFromWhenFailedDueToSmallNumberOfParts() throws IOException
+    {
+        final String boundary = UUID.randomUUID().toString();
+        final String responseBody = "--" + boundary + "\r\n"
+            + "Content-Type: application/octet-stream; charset=UTF-8\r\n"
+            + "Content-Disposition: attachment; filename=\"myfile.properties\";\r\n"
+            + "\r\n"
+            + "key1=value1\nkey2=value2\r\n"
+            + "--" + boundary + "--";
+
+        final MediaType fileMediaType = MediaType.valueOf("application/octet-stream; charset=UTF-8");
+
+        final MessageBodyReader<InputStream> inputStreamReader = mock(MessageBodyReader.class);
+        when(inputStreamReader.isReadable(InputStream.class, null, null, fileMediaType)).thenReturn(true);
+        when(inputStreamReader.readFrom(any(), any(), any(), any(), any(), any())).thenReturn(new ByteArrayInputStream("key1=value1\nkey2=value2".getBytes()));
+        when(workers.getMessageBodyReader(InputStream.class, null, new Annotation[] {}, fileMediaType)).thenReturn(inputStreamReader);
+
+        final MediaType metadataMediaType = MediaType.valueOf("application/json; charset=UTF-8");
+
+        final TranslatedFileMetadata translatedFileMetadata = mock(TranslatedFileMetadata.class);
+        final MessageBodyReader<TranslatedFileMetadata> metadataReader = mock(MessageBodyReader.class);
+        when(metadataReader.isReadable(TranslatedFileMetadata.class, TranslatedFileMetadata.class, null, metadataMediaType)).thenReturn(true);
+        when(metadataReader.readFrom(any(), any(), any(), any(), any(), any())).thenReturn(translatedFileMetadata);
+        when(workers.getMessageBodyReader(TranslatedFileMetadata.class, TranslatedFileMetadata.class, new Annotation[] {}, metadataMediaType)).thenReturn(metadataReader);
+
+        translatedFileMultipartReader.readFrom(
+            TranslatedFileMultipart.class,
+            TranslatedFileMultipart.class,
+            null,
+            MediaType.valueOf(MULTIPART_MIXED + "; boundary=" + boundary),
+            null,
+            new ByteArrayInputStream(responseBody.getBytes())
+        );
+    }
+
+    @Test(expected = IOException.class)
+    public void testReadFromWhenFailedDueToInvalidMetadataContentType() throws IOException
+    {
+        final String boundary = UUID.randomUUID().toString();
+        final String responseBody = "--" + boundary + "\r\n"
+            + "Content-Type: application/octet-stream; charset=UTF-8\r\n"
+            + "Content-Disposition: attachment; filename=\"myfile.properties\";\r\n"
+            + "\r\n"
+            + "key1=value1\nkey2=value2\r\n"
+            + "--" + boundary + "\r\n"
+            + "Content-Type: application/octet-stream; charset=UTF-8\r\n"
+            + "\r\n"
+            + "{\"key\":\"value\"}\r\n"
+            + "--" + boundary + "--";
+
+        final MediaType fileMediaType = MediaType.valueOf("application/octet-stream; charset=UTF-8");
+
+        final MessageBodyReader<InputStream> inputStreamReader = mock(MessageBodyReader.class);
+        when(inputStreamReader.isReadable(InputStream.class, null, null, fileMediaType)).thenReturn(true);
+        when(inputStreamReader.readFrom(any(), any(), any(), any(), any(), any())).thenReturn(new ByteArrayInputStream("key1=value1\nkey2=value2".getBytes()));
+        when(workers.getMessageBodyReader(InputStream.class, null, new Annotation[] {}, fileMediaType)).thenReturn(inputStreamReader);
+
+        final MediaType metadataMediaType = MediaType.valueOf("application/octet-stream; charset=UTF-8");
+
+        final TranslatedFileMetadata translatedFileMetadata = mock(TranslatedFileMetadata.class);
+        final MessageBodyReader<TranslatedFileMetadata> metadataReader = mock(MessageBodyReader.class);
+        when(metadataReader.isReadable(TranslatedFileMetadata.class, TranslatedFileMetadata.class, null, metadataMediaType)).thenReturn(true);
+        when(metadataReader.readFrom(any(), any(), any(), any(), any(), any())).thenReturn(translatedFileMetadata);
+        when(workers.getMessageBodyReader(TranslatedFileMetadata.class, TranslatedFileMetadata.class, new Annotation[] {}, metadataMediaType)).thenReturn(metadataReader);
+
+        translatedFileMultipartReader.readFrom(
+            TranslatedFileMultipart.class,
+            TranslatedFileMultipart.class,
+            null,
+            MediaType.valueOf(MULTIPART_MIXED + "; boundary=" + boundary),
+            null,
+            new ByteArrayInputStream(responseBody.getBytes())
+        );
+    }
+
+    @Test(expected = IOException.class)
+    public void testReadFromWhenFailedDueToInvalidMetadataJson() throws IOException
+    {
+        final String boundary = UUID.randomUUID().toString();
+        final String responseBody = "--" + boundary + "\r\n"
+            + "Content-Type: application/octet-stream; charset=UTF-8\r\n"
+            + "Content-Disposition: attachment; filename=\"myfile.properties\";\r\n"
+            + "\r\n"
+            + "key1=value1\nkey2=value2\r\n"
+            + "--" + boundary + "\r\n"
+            + "Content-Type: application/json; charset=UTF-8\r\n"
+            + "\r\n"
+            + "{\"key\":\"value\"}\r\n"
+            + "--" + boundary + "--";
+
+        final MediaType fileMediaType = MediaType.valueOf("application/octet-stream; charset=UTF-8");
+
+        final MessageBodyReader<InputStream> inputStreamReader = mock(MessageBodyReader.class);
+        when(inputStreamReader.isReadable(InputStream.class, null, null, fileMediaType)).thenReturn(true);
+        when(inputStreamReader.readFrom(any(), any(), any(), any(), any(), any())).thenReturn(new ByteArrayInputStream("key1=value1\nkey2=value2".getBytes()));
+        when(workers.getMessageBodyReader(InputStream.class, null, new Annotation[] {}, fileMediaType)).thenReturn(inputStreamReader);
+
+        final MediaType metadataMediaType = MediaType.valueOf("application/json; charset=UTF-8");
+
+        final MessageBodyReader<TranslatedFileMetadata> metadataReader = mock(MessageBodyReader.class);
+        when(metadataReader.isReadable(TranslatedFileMetadata.class, TranslatedFileMetadata.class, null, metadataMediaType)).thenReturn(true);
+        when(metadataReader.readFrom(any(), any(), any(), any(), any(), any())).thenReturn(null);
+        when(workers.getMessageBodyReader(TranslatedFileMetadata.class, TranslatedFileMetadata.class, new Annotation[] {}, metadataMediaType)).thenReturn(metadataReader);
+
+        translatedFileMultipartReader.readFrom(
+            TranslatedFileMultipart.class,
+            TranslatedFileMultipart.class,
+            null,
+            MediaType.valueOf(MULTIPART_MIXED + "; boundary=" + boundary),
+            null,
+            new ByteArrayInputStream(responseBody.getBytes())
+        );
+    }
+}


### PR DESCRIPTION
new method to download a translated file in the multipart/mixed format is added to Files API. the first part is file's body, the second part is json metadata (empty for now, we use it just to be sure that entire file was downloaded, maybe we will extend it with some additional data in the future) 
