### PR TITLE
fix: Release 1.12.4. APIs are auto-closeable.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.smartling.api</groupId>
     <artifactId>smartling-sdk-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.12.4</version>
+    <version>1.12.6</version>
     <name>Smartling API Parent</name>
     <description>Smartling API SDK</description>
     <url>https://api-reference.smartling.com</url>
@@ -13,7 +13,7 @@
     <scm>
         <url>https://github.com/Smartling/java-api-sdk</url>
         <developerConnection>scm:git:ssh://git@github.com/Smartling/java-api-sdk</developerConnection>
-        <tag>v1.12.4</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.smartling.api</groupId>
     <artifactId>smartling-sdk-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.12.3-SNAPSHOT</version>
+    <version>1.12.4</version>
     <name>Smartling API Parent</name>
     <description>Smartling API SDK</description>
     <url>https://api-reference.smartling.com</url>
@@ -13,7 +13,7 @@
     <scm>
         <url>https://github.com/Smartling/java-api-sdk</url>
         <developerConnection>scm:git:ssh://git@github.com/Smartling/java-api-sdk</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v1.12.4</tag>
     </scm>
 
     <licenses>

--- a/samrtling-api-test-utils/pom.xml
+++ b/samrtling-api-test-utils/pom.xml
@@ -4,13 +4,13 @@
 
     <artifactId>smartling-api-test-utils</artifactId>
     <packaging>jar</packaging>
-    <version>1.12.4</version>
+    <version>1.12.6</version>
     <name>Smartling API Test Utils</name>
 
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.4</version>
+        <version>1.12.6</version>
     </parent>
 
     <dependencies>

--- a/samrtling-api-test-utils/pom.xml
+++ b/samrtling-api-test-utils/pom.xml
@@ -4,13 +4,13 @@
 
     <artifactId>smartling-api-test-utils</artifactId>
     <packaging>jar</packaging>
-    <version>1.12.3-SNAPSHOT</version>
+    <version>1.12.4</version>
     <name>Smartling API Test Utils</name>
 
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.3-SNAPSHOT</version>
+        <version>1.12.4</version>
     </parent>
 
     <dependencies>

--- a/smartling-accounts-api/pom.xml
+++ b/smartling-accounts-api/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.4</version>
+        <version>1.12.6</version>
     </parent>
 
     <artifactId>smartling-accounts-api</artifactId>
-    <version>1.12.4</version>
+    <version>1.12.6</version>
     <name>Smartling Accounts API</name>
 
     <dependencies>

--- a/smartling-accounts-api/pom.xml
+++ b/smartling-accounts-api/pom.xml
@@ -5,18 +5,18 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.3-SNAPSHOT</version>
+        <version>1.12.4</version>
     </parent>
 
     <artifactId>smartling-accounts-api</artifactId>
-    <version>1.12.3-SNAPSHOT</version>
+    <version>1.12.4</version>
     <name>Smartling Accounts API</name>
 
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-api-commons/pom.xml
+++ b/smartling-api-commons/pom.xml
@@ -3,13 +3,13 @@
 
     <artifactId>smartling-api-commons</artifactId>
     <packaging>jar</packaging>
-    <version>1.12.4</version>
+    <version>1.12.6</version>
     <name>Smartling API Commons</name>
 
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.4</version>
+        <version>1.12.6</version>
     </parent>
 
     <build>

--- a/smartling-api-commons/pom.xml
+++ b/smartling-api-commons/pom.xml
@@ -3,13 +3,13 @@
 
     <artifactId>smartling-api-commons</artifactId>
     <packaging>jar</packaging>
-    <version>1.12.3-SNAPSHOT</version>
+    <version>1.12.4</version>
     <name>Smartling API Commons</name>
 
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.3-SNAPSHOT</version>
+        <version>1.12.4</version>
     </parent>
 
     <build>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-test-utils</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/smartling-api-sdk-all/pom.xml
+++ b/smartling-api-sdk-all/pom.xml
@@ -4,10 +4,10 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.4</version>
+        <version>1.12.6</version>
     </parent>
     <artifactId>smartling-api-sdk</artifactId>
-    <version>1.12.4</version>
+    <version>1.12.6</version>
     <packaging>jar</packaging>
     <name>Smartling API SDK</name>
     <dependencies>

--- a/smartling-api-sdk-all/pom.xml
+++ b/smartling-api-sdk-all/pom.xml
@@ -4,78 +4,78 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.3-SNAPSHOT</version>
+        <version>1.12.4</version>
     </parent>
     <artifactId>smartling-api-sdk</artifactId>
-    <version>1.12.3-SNAPSHOT</version>
+    <version>1.12.4</version>
     <packaging>jar</packaging>
     <name>Smartling API SDK</name>
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-accounts-api</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-issues-api</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-locales-api</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-jobs-api</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-job-batches-api</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-files-api</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-projects-api</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-strings-api</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-contexts-api</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-attachments-api</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-reports-api</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-glossary-api</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-file-translations-api</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-attachments-api/pom.xml
+++ b/smartling-attachments-api/pom.xml
@@ -4,16 +4,16 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.3-SNAPSHOT</version>
+        <version>1.12.4</version>
     </parent>
     <artifactId>smartling-attachments-api</artifactId>
-    <version>1.12.3-SNAPSHOT</version>
+    <version>1.12.4</version>
     <name>Smartling Attachments API</name>
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-attachments-api/pom.xml
+++ b/smartling-attachments-api/pom.xml
@@ -4,10 +4,10 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.4</version>
+        <version>1.12.6</version>
     </parent>
     <artifactId>smartling-attachments-api</artifactId>
-    <version>1.12.4</version>
+    <version>1.12.6</version>
     <name>Smartling Attachments API</name>
     <dependencies>
         <dependency>

--- a/smartling-contexts-api/pom.xml
+++ b/smartling-contexts-api/pom.xml
@@ -4,10 +4,10 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.4</version>
+        <version>1.12.6</version>
     </parent>
     <artifactId>smartling-contexts-api</artifactId>
-    <version>1.12.4</version>
+    <version>1.12.6</version>
     <name>Smartling Contexts API</name>
     <dependencies>
         <dependency>

--- a/smartling-contexts-api/pom.xml
+++ b/smartling-contexts-api/pom.xml
@@ -4,16 +4,16 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.3-SNAPSHOT</version>
+        <version>1.12.4</version>
     </parent>
     <artifactId>smartling-contexts-api</artifactId>
-    <version>1.12.3-SNAPSHOT</version>
+    <version>1.12.4</version>
     <name>Smartling Contexts API</name>
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-file-translations-api/pom.xml
+++ b/smartling-file-translations-api/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.3-SNAPSHOT</version>
+        <version>1.12.4</version>
     </parent>
 
     <artifactId>smartling-file-translations-api</artifactId>
-    <version>1.12.3-SNAPSHOT</version>
+    <version>1.12.4</version>
     <name>Smartling File Translations API</name>
 
     <build>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-test-utils</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/smartling-file-translations-api/pom.xml
+++ b/smartling-file-translations-api/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.4</version>
+        <version>1.12.6</version>
     </parent>
 
     <artifactId>smartling-file-translations-api</artifactId>
-    <version>1.12.4</version>
+    <version>1.12.6</version>
     <name>Smartling File Translations API</name>
 
     <build>

--- a/smartling-files-api/pom.xml
+++ b/smartling-files-api/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.4</version>
+        <version>1.12.6</version>
     </parent>
 
     <artifactId>smartling-files-api</artifactId>
-    <version>1.12.4</version>
+    <version>1.12.6</version>
     <name>Smartling Content Files API</name>
 
     <build>

--- a/smartling-files-api/pom.xml
+++ b/smartling-files-api/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.3-SNAPSHOT</version>
+        <version>1.12.4</version>
     </parent>
 
     <artifactId>smartling-files-api</artifactId>
-    <version>1.12.3-SNAPSHOT</version>
+    <version>1.12.4</version>
     <name>Smartling Content Files API</name>
 
     <build>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-test-utils</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/smartling-glossary-api/pom.xml
+++ b/smartling-glossary-api/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.3-SNAPSHOT</version>
+        <version>1.12.4</version>
     </parent>
 
     <artifactId>smartling-glossary-api</artifactId>
-    <version>1.12.3-SNAPSHOT</version>
+    <version>1.12.4</version>
     <name>Smartling Glossary API</name>
 
     <build>
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-test-utils</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/smartling-glossary-api/pom.xml
+++ b/smartling-glossary-api/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.4</version>
+        <version>1.12.6</version>
     </parent>
 
     <artifactId>smartling-glossary-api</artifactId>
-    <version>1.12.4</version>
+    <version>1.12.6</version>
     <name>Smartling Glossary API</name>
 
     <build>

--- a/smartling-issues-api/pom.xml
+++ b/smartling-issues-api/pom.xml
@@ -5,18 +5,18 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.3-SNAPSHOT</version>
+        <version>1.12.4</version>
     </parent>
 
     <artifactId>smartling-issues-api</artifactId>
-    <version>1.12.3-SNAPSHOT</version>
+    <version>1.12.4</version>
     <name>Smartling Issues API</name>
 
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-issues-api/pom.xml
+++ b/smartling-issues-api/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.4</version>
+        <version>1.12.6</version>
     </parent>
 
     <artifactId>smartling-issues-api</artifactId>
-    <version>1.12.4</version>
+    <version>1.12.6</version>
     <name>Smartling Issues API</name>
 
     <dependencies>

--- a/smartling-job-batches-api/pom.xml
+++ b/smartling-job-batches-api/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.3-SNAPSHOT</version>
+        <version>1.12.4</version>
     </parent>
 
     <artifactId>smartling-job-batches-api</artifactId>
-    <version>1.12.3-SNAPSHOT</version>
+    <version>1.12.4</version>
     <name>Smartling Job Batches API</name>
 
     <build>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-job-batches-api/pom.xml
+++ b/smartling-job-batches-api/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.4</version>
+        <version>1.12.6</version>
     </parent>
 
     <artifactId>smartling-job-batches-api</artifactId>
-    <version>1.12.4</version>
+    <version>1.12.6</version>
     <name>Smartling Job Batches API</name>
 
     <build>

--- a/smartling-jobs-api/pom.xml
+++ b/smartling-jobs-api/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.4</version>
+        <version>1.12.6</version>
     </parent>
 
     <artifactId>smartling-jobs-api</artifactId>
-    <version>1.12.4</version>
+    <version>1.12.6</version>
     <name>Smartling Jobs API</name>
 
     <dependencies>

--- a/smartling-jobs-api/pom.xml
+++ b/smartling-jobs-api/pom.xml
@@ -5,18 +5,18 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.3-SNAPSHOT</version>
+        <version>1.12.4</version>
     </parent>
 
     <artifactId>smartling-jobs-api</artifactId>
-    <version>1.12.3-SNAPSHOT</version>
+    <version>1.12.4</version>
     <name>Smartling Jobs API</name>
 
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-locales-api/pom.xml
+++ b/smartling-locales-api/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <groupId>com.smartling.api</groupId>
     <artifactId>smartling-sdk-parent</artifactId>
-    <version>1.12.4</version>
+    <version>1.12.6</version>
   </parent>
   <artifactId>smartling-locales-api</artifactId>
-  <version>1.12.4</version>
+  <version>1.12.6</version>
   <name>Smartling Locales API</name>
   <dependencies>
     <dependency>

--- a/smartling-locales-api/pom.xml
+++ b/smartling-locales-api/pom.xml
@@ -4,16 +4,16 @@
   <parent>
     <groupId>com.smartling.api</groupId>
     <artifactId>smartling-sdk-parent</artifactId>
-    <version>1.12.3-SNAPSHOT</version>
+    <version>1.12.4</version>
   </parent>
   <artifactId>smartling-locales-api</artifactId>
-  <version>1.12.3-SNAPSHOT</version>
+  <version>1.12.4</version>
   <name>Smartling Locales API</name>
   <dependencies>
     <dependency>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-api-commons</artifactId>
-        <version>1.12.3-SNAPSHOT</version>
+        <version>1.12.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/smartling-projects-api/pom.xml
+++ b/smartling-projects-api/pom.xml
@@ -4,16 +4,16 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.3-SNAPSHOT</version>
+        <version>1.12.4</version>
     </parent>
     <artifactId>smartling-projects-api</artifactId>
-    <version>1.12.3-SNAPSHOT</version>
+    <version>1.12.4</version>
     <name>Smartling Projects API</name>
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-projects-api/pom.xml
+++ b/smartling-projects-api/pom.xml
@@ -4,10 +4,10 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.4</version>
+        <version>1.12.6</version>
     </parent>
     <artifactId>smartling-projects-api</artifactId>
-    <version>1.12.4</version>
+    <version>1.12.6</version>
     <name>Smartling Projects API</name>
     <dependencies>
         <dependency>

--- a/smartling-reports-api/pom.xml
+++ b/smartling-reports-api/pom.xml
@@ -4,16 +4,16 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.3-SNAPSHOT</version>
+        <version>1.12.4</version>
     </parent>
     <artifactId>smartling-reports-api</artifactId>
-    <version>1.12.3-SNAPSHOT</version>
+    <version>1.12.4</version>
     <name>Smartling Reports API</name>
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
     </dependencies>
 </project>

--- a/smartling-reports-api/pom.xml
+++ b/smartling-reports-api/pom.xml
@@ -4,10 +4,10 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.4</version>
+        <version>1.12.6</version>
     </parent>
     <artifactId>smartling-reports-api</artifactId>
-    <version>1.12.4</version>
+    <version>1.12.6</version>
     <name>Smartling Reports API</name>
     <dependencies>
         <dependency>

--- a/smartling-strings-api/pom.xml
+++ b/smartling-strings-api/pom.xml
@@ -4,10 +4,10 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.4</version>
+        <version>1.12.6</version>
     </parent>
     <artifactId>smartling-strings-api</artifactId>
-    <version>1.12.4</version>
+    <version>1.12.6</version>
     <name>Smartling Strings API</name>
     <dependencies>
         <dependency>

--- a/smartling-strings-api/pom.xml
+++ b/smartling-strings-api/pom.xml
@@ -4,16 +4,16 @@
     <parent>
         <groupId>com.smartling.api</groupId>
         <artifactId>smartling-sdk-parent</artifactId>
-        <version>1.12.3-SNAPSHOT</version>
+        <version>1.12.4</version>
     </parent>
     <artifactId>smartling-strings-api</artifactId>
-    <version>1.12.3-SNAPSHOT</version>
+    <version>1.12.4</version>
     <name>Smartling Strings API</name>
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>
             <artifactId>smartling-api-commons</artifactId>
-            <version>1.12.3-SNAPSHOT</version>
+            <version>1.12.4</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
[JIRA Ticket](https://smartling.atlassian.net/browse/AEM-854)

fix: APIs are auto-closeable. It allows user to release network resources used for making an API.