### PR TITLE
feat: pass correct filename on attachment upload

### DIFF
--- a/smartling-api-commons/src/main/java/com/smartling/resteasy/ext/FileFormParam.java
+++ b/smartling-api-commons/src/main/java/com/smartling/resteasy/ext/FileFormParam.java
@@ -1,0 +1,23 @@
+package com.smartling.resteasy.ext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Must be used in conjunction with {@link org.jboss.resteasy.annotations.providers.multipart.PartType}.
+ * It defines file form data with filename.
+ * <p>
+ * It is a replacement for {@link javax.ws.rs.FormParam} and {@link org.jboss.resteasy.annotations.jaxrs.FormParam}
+ * and should not be used together on the same field.
+ * <p>
+ * Be careful, it may not fully replace FormParam functionality.
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface FileFormParam
+{
+    String value();
+    String filenameField() default "";
+}

--- a/smartling-api-commons/src/test/java/com/smartling/resteasy/ext/ExtendedMultipartFormWriterTest.java
+++ b/smartling-api-commons/src/test/java/com/smartling/resteasy/ext/ExtendedMultipartFormWriterTest.java
@@ -1,18 +1,21 @@
 package com.smartling.resteasy.ext;
 
 import com.smartling.resteasy.ext.data.FormWithDynamicParams;
+import com.smartling.resteasy.ext.data.FormWithFileFormParams;
 import com.smartling.resteasy.ext.data.FormWithListParams;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static java.lang.Boolean.TRUE;
+import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM_TYPE;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -85,4 +88,26 @@ public class ExtendedMultipartFormWriterTest
         verifyNoMoreInteractions(output);
     }
 
+    @Test
+    public void shouldExtractFileFormParams() throws Exception
+    {
+        MultipartFormDataOutput output = mock(MultipartFormDataOutput.class);
+        InputStream ins1 = mock(InputStream.class);
+        InputStream ins2 = mock(InputStream.class);
+        InputStream ins3 = mock(InputStream.class);
+
+        FormWithFileFormParams form = new FormWithFileFormParams();
+        form.setFile1(ins1);
+        form.setFile1Name("file1.txt");
+        form.setFile2(ins2);
+        form.setFile3(ins3);
+
+        testedInstance.getFields(FormWithFileFormParams.class, output, form);
+
+        verify(output).addFormData(eq("file1"), eq(ins1), eq(InputStream.class), eq(InputStream.class), eq(APPLICATION_OCTET_STREAM_TYPE), eq("file1.txt"));
+        verify(output).addFormData(eq("file2"), eq(ins2), eq(InputStream.class), eq(InputStream.class), eq(APPLICATION_OCTET_STREAM_TYPE), eq("file2"));
+        verify(output).addFormData(eq("file3"), eq(ins3), eq(InputStream.class), eq(InputStream.class), eq(APPLICATION_OCTET_STREAM_TYPE), isNull());
+        verify(output).addFormData(eq("file1Name"), eq("file1.txt"), eq(String.class), eq(String.class), eq(TEXT_PLAIN_TYPE), isNull());
+        verifyNoMoreInteractions(output);
+    }
 }

--- a/smartling-api-commons/src/test/java/com/smartling/resteasy/ext/data/DummyMultipartApi.java
+++ b/smartling-api-commons/src/test/java/com/smartling/resteasy/ext/data/DummyMultipartApi.java
@@ -21,4 +21,9 @@ public interface DummyMultipartApi
     @Consumes(MULTIPART_FORM_DATA)
     @Path(DUMMY_MULTIPART_API + "/list-fields")
     void postListParams(@MultipartForm FormWithListParams form);
+
+    @POST
+    @Consumes(MULTIPART_FORM_DATA)
+    @Path(DUMMY_MULTIPART_API + "/file-fields")
+    void postFileFormParams(@MultipartForm FormWithFileFormParams form);
 }

--- a/smartling-api-commons/src/test/java/com/smartling/resteasy/ext/data/FormWithFileFormParams.java
+++ b/smartling-api-commons/src/test/java/com/smartling/resteasy/ext/data/FormWithFileFormParams.java
@@ -1,0 +1,30 @@
+package com.smartling.resteasy.ext.data;
+
+import com.smartling.resteasy.ext.FileFormParam;
+import lombok.Data;
+import org.jboss.resteasy.annotations.providers.multipart.PartFilename;
+import org.jboss.resteasy.annotations.providers.multipart.PartType;
+
+import javax.ws.rs.FormParam;
+import java.io.InputStream;
+
+@Data
+public class FormWithFileFormParams
+{
+    @FileFormParam(value = "file1", filenameField = "file1Name")
+    @PartType("application/octet-stream")
+    private InputStream file1;
+
+    @FileFormParam("file2")
+    @PartFilename("file2")
+    @PartType("application/octet-stream")
+    private InputStream file2;
+
+    @FileFormParam("file3")
+    @PartType("application/octet-stream")
+    private InputStream file3;
+
+    @FormParam("file1Name")
+    @PartType("text/plain")
+    private String file1Name;
+}

--- a/smartling-attachments-api/src/main/java/com/smartling/api/attachments/v2/pto/AttachmentUploadPTO.java
+++ b/smartling-attachments-api/src/main/java/com/smartling/api/attachments/v2/pto/AttachmentUploadPTO.java
@@ -1,5 +1,6 @@
 package com.smartling.api.attachments.v2.pto;
 
+import com.smartling.resteasy.ext.FileFormParam;
 import com.smartling.resteasy.ext.ListFormParam;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -16,8 +17,7 @@ import java.util.List;
 @AllArgsConstructor
 public class AttachmentUploadPTO
 {
-    @FormParam("file")
-    @PartFilename("file")
+    @FileFormParam(value = "file", filenameField = "name")
     @PartType("application/octet-stream")
     private InputStream file;
 

--- a/smartling-attachments-api/src/test/java/com/smartling/api/attachments/v2/AttachmentsApiTest.java
+++ b/smartling-attachments-api/src/test/java/com/smartling/api/attachments/v2/AttachmentsApiTest.java
@@ -178,7 +178,7 @@ public class AttachmentsApiTest
         String partSeparator = requestBody.substring(0, 38);
 
         assertEquals(requestBody, partSeparator + "\r\n" +
-            "Content-Disposition: form-data; name=\"file\"; filename=\"file\"\r\n" +
+            "Content-Disposition: form-data; name=\"file\"; filename=\"test.txt\"\r\n" +
             "Content-Type: application/octet-stream\r\n" +
             "\r\n" +
             "content\r\n" +


### PR DESCRIPTION
[WKFT-138](https://smartling.atlassian.net/browse/WKFT-138)
- Extend RESTEasy's MultipartFormAnnotationWriter to pass filename in Content-Disposition header.
- Pass correct filename on attachment upload

[WKFT-138]: https://smartling.atlassian.net/browse/WKFT-138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ