### PR TITLE
fix: fix sdk-project.properties project variables substitution

### DIFF
--- a/smartling-accounts-api/pom.xml
+++ b/smartling-accounts-api/pom.xml
@@ -12,6 +12,15 @@
     <version>1.19.1-SNAPSHOT</version>
     <name>Smartling Accounts API</name>
 
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>

--- a/smartling-attachments-api/pom.xml
+++ b/smartling-attachments-api/pom.xml
@@ -9,6 +9,16 @@
     <artifactId>smartling-attachments-api</artifactId>
     <version>1.19.1-SNAPSHOT</version>
     <name>Smartling Attachments API</name>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>

--- a/smartling-contexts-api/pom.xml
+++ b/smartling-contexts-api/pom.xml
@@ -9,6 +9,16 @@
     <artifactId>smartling-contexts-api</artifactId>
     <version>1.19.1-SNAPSHOT</version>
     <name>Smartling Contexts API</name>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>

--- a/smartling-issues-api/pom.xml
+++ b/smartling-issues-api/pom.xml
@@ -12,6 +12,15 @@
     <version>1.19.1-SNAPSHOT</version>
     <name>Smartling Issues API</name>
 
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>

--- a/smartling-jobs-api/pom.xml
+++ b/smartling-jobs-api/pom.xml
@@ -12,6 +12,16 @@
     <version>1.19.1-SNAPSHOT</version>
     <name>Smartling Jobs API</name>
 
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>

--- a/smartling-locales-api/pom.xml
+++ b/smartling-locales-api/pom.xml
@@ -1,19 +1,28 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>com.smartling.api</groupId>
-    <artifactId>smartling-sdk-parent</artifactId>
-    <version>1.19.1-SNAPSHOT</version>
-  </parent>
-  <artifactId>smartling-locales-api</artifactId>
-  <version>1.19.1-SNAPSHOT</version>
-  <name>Smartling Locales API</name>
-  <dependencies>
-    <dependency>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
         <groupId>com.smartling.api</groupId>
-        <artifactId>smartling-api-commons</artifactId>
+        <artifactId>smartling-sdk-parent</artifactId>
         <version>1.19.1-SNAPSHOT</version>
-    </dependency>
-  </dependencies>
+    </parent>
+    <artifactId>smartling-locales-api</artifactId>
+    <version>1.19.1-SNAPSHOT</version>
+    <name>Smartling Locales API</name>
+    
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>com.smartling.api</groupId>
+            <artifactId>smartling-api-commons</artifactId>
+            <version>1.19.1-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/smartling-mt-router-api/pom.xml
+++ b/smartling-mt-router-api/pom.xml
@@ -11,6 +11,15 @@
     <version>1.19.1-SNAPSHOT</version>
     <name>Smartling MT Router API</name>
 
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>

--- a/smartling-projects-api/pom.xml
+++ b/smartling-projects-api/pom.xml
@@ -9,6 +9,16 @@
     <artifactId>smartling-projects-api</artifactId>
     <version>1.19.1-SNAPSHOT</version>
     <name>Smartling Projects API</name>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>

--- a/smartling-reports-api/pom.xml
+++ b/smartling-reports-api/pom.xml
@@ -9,6 +9,16 @@
     <artifactId>smartling-reports-api</artifactId>
     <version>1.19.1-SNAPSHOT</version>
     <name>Smartling Reports API</name>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>

--- a/smartling-strings-api/pom.xml
+++ b/smartling-strings-api/pom.xml
@@ -9,6 +9,16 @@
     <artifactId>smartling-strings-api</artifactId>
     <version>1.19.1-SNAPSHOT</version>
     <name>Smartling Strings API</name>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>com.smartling.api</groupId>


### PR DESCRIPTION
Generated sdk-project.properties, which is included within sdk jar, for many sdks contains unextended project variables.
<img width="766" alt="Screenshot 2025-06-12 at 9 53 22 AM" src="https://github.com/user-attachments/assets/7f83c16c-7a41-4149-9b01-f432d56e4343" />

When one uses sdk, by default properties taken from sdk-project.properties are used to generate User-agent header which leads to user-agent header looking like this in our apigateway log:
```2025-06-10 11:15:47:682 +0000 - [INFO] [http-nio-8443-exec-431] (RequestSummaryFilter.java:run:159) rid=002a673a-966e-4ec6-a0de-442b8c7e52fa#tqdm 	[MAINLOG] Request finished, status_code=200, service_id=JOBS-SERVICE, total_time=36, auth_filter_time=29, user=service+email-notifications@smartling.com, method=POST, url="https://api.smartling.com/jobs-admin-api/v3/projects/f67df5d74/find-jobs-by-content", service_uri="/jobs-admin-api/v3/projects/f67df5d74/find-jobs-by-content", auth_source=header, user_agent="${project.artifactId}-java/${project.version}", exception_happened=false, service_origin="email-notifications-service", projectId=f67df5d74```

The way to fix it is substitute project.artifactId and project.version variables in sdk-project.properties when this file is copied into the jar file during build process. So in the end we would have correct sdk-project.properties file inside sdk's jar:
<img width="900" alt="Screenshot 2025-06-12 at 10 01 30 AM" src="https://github.com/user-attachments/assets/35009bf8-472b-4992-881b-10443006d95d" />

To do this we need to use [filtering](https://maven.apache.org/plugins/maven-resources-plugin/examples/filter.html) when we copy resources into jar.
https://smartling.atlassian.net/browse/TCM-5747


