### PR TITLE
feat: deploy to Central Publisher Portal instead of sonatype OSSRH

### DIFF
--- a/.circleci/release.sh
+++ b/.circleci/release.sh
@@ -9,4 +9,13 @@ if ! ./mvnw -Prelease conventional-commits:validate; then
 fi
 
 ./mvnw -B -Prelease -DskipTests -Darguments='-DskipTests' -s .circleci/settings.xml conventional-commits:version release:prepare
-./mvnw -B -DskipTests -Darguments=-DskipTests -s .circleci/settings.xml release:perform
+
+# Get the tag created by release:prepare
+TAG=$(git describe --tags --abbrev=0)
+echo "Deploying tag: $TAG"
+
+# Checkout the tagged version
+git checkout $TAG
+
+# Deploy using central-publishing-maven-plugin
+./mvnw -B -Prelease -DskipTests -s .circleci/settings.xml clean deploy

--- a/.circleci/settings.xml
+++ b/.circleci/settings.xml
@@ -18,9 +18,9 @@
 
   <servers>
     <server>
-      <id>sonatype-oss-staging</id>
-      <username>${env.SONATYPE_USERNAME}</username>
-      <password>${env.SONATYPE_PASSWORD}</password>
+      <id>central</id>
+      <username>${env.CENTRAL_SONATYPE_USERNAME}</username>
+      <password>${env.CENTRAL_SONATYPE_PASSWORD}</password>
     </server>
   </servers>
 </settings>

--- a/pom.xml
+++ b/pom.xml
@@ -207,10 +207,6 @@
     </developers>
 
     <distributionManagement>
-        <repository>
-            <id>sonatype-oss-staging</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
         <snapshotRepository>
             <id>github</id>
             <url>https://maven.pkg.github.com/smartling/java-api-sdk</url>
@@ -238,6 +234,47 @@
                             <tagNameFormat>v@{project.version}</tagNameFormat>
                             <allowTimestampedSnapshots>false</allowTimestampedSnapshots>
                             <scmCommentPrefix xml:space="preserve">ci: </scmCommentPrefix>
+                            <!-- Skip release:perform goal - use central-publishing-maven-plugin instead -->
+                            <goals>prepare</goals>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.1.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>false</autoPublish>
+                            <waitUntil>uploaded</waitUntil>
+                            <checksums>required</checksums>
+                            <deploymentName>Java API SDK (${project.version})</deploymentName>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Tested in https://github.com/Smartling/java-api-sdk/pull/121
Job: https://app.circleci.com/pipelines/github/Smartling/java-api-sdk/461/workflows/761ea226-8811-4d7d-9e88-a8ddaa9c4943
https://central.sonatype.com/publishing/deployments:
<img width="1679" height="762" alt="image" src="https://github.com/user-attachments/assets/48591ee4-7326-496b-aa76-b69b44fbf33b" />
