### PR TITLE
feat: Migrate codebase and dependencies to Java 17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
     test:
         docker:
-            - image: openjdk:11
+            - image: openjdk:17
         steps:
             - checkout
             - run:
@@ -17,7 +17,7 @@ jobs:
                   path: test-results
     deploy:
         docker:
-            - image: openjdk:11
+            - image: openjdk:17
         steps:
             - add_ssh_keys:
                   fingerprints:
@@ -49,4 +49,6 @@ workflows:
                       - test
                   filters:
                       branches:
-                          only: master
+                          only:
+                              - master
+                              - 2.x

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.2/apache-maven-3.6.2-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar

--- a/README.md
+++ b/README.md
@@ -2,6 +2,26 @@
 
 Java SDK for integrating with the [Smartling API].
 
+> **Note**: Version 2.x requires Java 17+. If you need Java 8 compatibility, use version 1.x (maintenance mode).
+
+## SDK Versions
+
+We maintain two major versions of this SDK:
+
+### Version 2.x (Current - Recommended)
+- **Branch**: `2.x`
+- **Java Compatibility**: Java 17+
+- **Status**: Active development
+- **Recommendation**: All new projects should use 2.x. Existing projects are strongly encouraged to migrate.
+
+### Version 1.x (Maintenance Mode)
+- **Branch**: `master`
+- **Java Compatibility**: Java 8+
+- **Status**: Maintenance only - critical fixes and security updates
+- **Future**: Will be deprecated once migration to 2.x is complete
+
+We strongly encourage all users to migrate to version 2.x to benefit from modern Java features, improved performance, and continued feature development. Version 1.x will eventually be deprecated as Smartling projects and clients complete their migration.
+
 ## Using this SDK
 
 The Smartling API SDK is distributed via Maven Central and is compatible with JDK 1.7

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <org.powermock.version>2.0.4</org.powermock.version>
         <org.jboss.resteasy.version>4.7.10.Final</org.jboss.resteasy.version>
         <apache.httpclient.version>4.5.14</apache.httpclient.version>
         <jackson.version>2.15.4</jackson.version>
@@ -36,6 +35,11 @@
 
     <dependencyManagement>
         <dependencies>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
@@ -46,9 +50,14 @@
 
     <dependencies>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.10</version>
+            <version>1.18.34</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -79,24 +88,24 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.28</version>
+            <version>2.0.16</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.28</version>
+            <version>2.0.16</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.28.2</version>
+            <version>5.14.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -118,10 +127,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.13.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                     <compilerArgs>
                         <arg>-parameters</arg>
                     </compilerArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -28,9 +28,9 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <org.jboss.resteasy.version>4.7.10.Final</org.jboss.resteasy.version>
         <apache.httpclient.version>4.5.14</apache.httpclient.version>
-        <jackson.version>2.15.4</jackson.version>
+        <jackson.version>2.17.3</jackson.version>
         <okhttp.version>4.12.0</okhttp.version>
-        <wiremock.version>2.27.2</wiremock.version>
+        <wiremock.version>2.35.2</wiremock.version>
     </properties>
 
     <dependencyManagement>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.34</version>
+            <version>1.18.38</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.14.2</version>
+            <version>5.18.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -116,7 +116,7 @@
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-jre8</artifactId>
             <version>${wiremock.version}</version>
             <scope>test</scope>
         </dependency>
@@ -139,7 +139,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
+                <version>3.2.7</version>
                 <configuration>
                     <gpgArguments>
                         <gpgArgument>--no-tty</gpgArgument>
@@ -161,7 +161,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.11.2</version>
                 <configuration>
                     <links>
                         <link>https://docs.oracle.com/javaee/7/api/</link>
@@ -235,7 +235,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-release-plugin</artifactId>
-                        <version>2.5.3</version>
+                        <version>3.1.1</version>
                         <configuration>
                             <autoVersionSubmodules>true</autoVersionSubmodules>
                             <dryRun>false</dryRun>
@@ -250,7 +250,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.2.1</version>
+                        <version>3.3.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -263,7 +263,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.1.1</version>
+                        <version>3.11.2</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -27,11 +27,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <org.powermock.version>2.0.4</org.powermock.version>
-        <org.jboss.resteasy.version>4.6.1.Final</org.jboss.resteasy.version>
+        <org.jboss.resteasy.version>4.7.10.Final</org.jboss.resteasy.version>
         <apache.httpclient.version>4.5.14</apache.httpclient.version>
-        <jackson.version>2.12.3</jackson.version>
-        <okhttp.version>4.9.3</okhttp.version>
-        <wiremock.version>2.26.0</wiremock.version>
+        <jackson.version>2.15.4</jackson.version>
+        <okhttp.version>4.12.0</okhttp.version>
+        <wiremock.version>2.27.2</wiremock.version>
     </properties>
 
     <dependencyManagement>

--- a/samrtling-api-test-utils/pom.xml
+++ b/samrtling-api-test-utils/pom.xml
@@ -19,5 +19,10 @@
             <artifactId>wiremock</artifactId>
             <version>${wiremock.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.17.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/samrtling-api-test-utils/pom.xml
+++ b/samrtling-api-test-utils/pom.xml
@@ -16,7 +16,7 @@
     <dependencies>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-jre8</artifactId>
             <version>${wiremock.version}</version>
         </dependency>
         <dependency>

--- a/smartling-api-commons/src/main/java/com/smartling/api/v2/client/DefaultClientConfiguration.java
+++ b/smartling-api-commons/src/main/java/com/smartling/api/v2/client/DefaultClientConfiguration.java
@@ -53,9 +53,12 @@ public class DefaultClientConfiguration implements ClientConfiguration
     @NonNull
     private HttpClientConfiguration httpClientConfiguration = new HttpClientConfiguration();
 
+    @Builder.Default
     private ResteasyProviderFactory resteasyProviderFactory = null;
 
+    @Builder.Default
     private RestApiExceptionMapper exceptionMapper = null;
 
+    @Builder.Default
     private LibNameVersionHolder libNameVersionHolder = null;
 }

--- a/smartling-api-commons/src/main/java/com/smartling/api/v2/client/unmarshal/RestApiContextResolver.java
+++ b/smartling-api-commons/src/main/java/com/smartling/api/v2/client/unmarshal/RestApiContextResolver.java
@@ -42,7 +42,7 @@ public class RestApiContextResolver implements ContextResolver<ObjectMapper>
             deserializerModule.addSerializer(klass, (JsonSerializer) classJsonSerializerMap.get(klass));
 
         objectMapper.registerModule(deserializerModule);
-        objectMapper.registerModule(new KotlinModule());
+        objectMapper.registerModule(new KotlinModule.Builder().build());
 
         this.objectMapper = objectMapper;
     }

--- a/smartling-api-commons/src/main/java/com/smartling/resteasy/ext/ExtendedMultipartFormWriter.java
+++ b/smartling-api-commons/src/main/java/com/smartling/resteasy/ext/ExtendedMultipartFormWriter.java
@@ -2,7 +2,6 @@ package com.smartling.resteasy.ext;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jboss.resteasy.annotations.providers.multipart.PartType;
-import org.jboss.resteasy.plugins.providers.multipart.FieldEnablerPrivilegedAction;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormAnnotationWriter;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
 import org.jboss.resteasy.spi.WriterException;
@@ -12,7 +11,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.ext.Provider;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.security.AccessController;
 import java.util.List;
 import java.util.Map;
 
@@ -39,7 +37,7 @@ public class ExtendedMultipartFormWriter extends MultipartFormAnnotationWriter
         {
             if (field.isAnnotationPresent(DynamicFormParam.class) && field.isAnnotationPresent(PartType.class))
             {
-                AccessController.doPrivileged(new FieldEnablerPrivilegedAction(field));
+                field.setAccessible(true);
 
                 Object value = safeExtractValue(obj, field);
 
@@ -67,7 +65,7 @@ public class ExtendedMultipartFormWriter extends MultipartFormAnnotationWriter
             }
             if (field.isAnnotationPresent(ListFormParam.class) && field.isAnnotationPresent(PartType.class))
             {
-                AccessController.doPrivileged(new FieldEnablerPrivilegedAction(field));
+                field.setAccessible(true);
                 Object value = safeExtractValue(obj, field);
 
                 if (value instanceof List)
@@ -88,7 +86,7 @@ public class ExtendedMultipartFormWriter extends MultipartFormAnnotationWriter
             }
             if (field.isAnnotationPresent(FileFormParam.class) && field.isAnnotationPresent(PartType.class))
             {
-                AccessController.doPrivileged(new FieldEnablerPrivilegedAction(field));
+                field.setAccessible(true);
 
                 FileFormParam fileFormParam = field.getAnnotation(FileFormParam.class);
                 String name = fileFormParam.value();
@@ -112,7 +110,7 @@ public class ExtendedMultipartFormWriter extends MultipartFormAnnotationWriter
             {
                 if (declaredField.getName().equals(filenameField))
                 {
-                    AccessController.doPrivileged(new FieldEnablerPrivilegedAction(declaredField));
+                    declaredField.setAccessible(true);
 
                     return (String) safeExtractValue(obj, declaredField);
                 }

--- a/smartling-api-commons/src/test/java/com/smartling/api/v2/auth/AuthenticationIntegrationTest.java
+++ b/smartling-api-commons/src/test/java/com/smartling/api/v2/auth/AuthenticationIntegrationTest.java
@@ -135,7 +135,7 @@ public class AuthenticationIntegrationTest
             "\t\t@javax.ws.rs.POST()\n" +
             "\t\t@javax.ws.rs.Path(\"/authenticate\")\n" +
             "\t]\n" +
-            "\theaders: [Content-Type=*/*,Matched-Stub-Id=" + stubMapping.getId() + ",Server=Jetty(9.2.28.v20190418),Transfer-Encoding=chunked,Vary=Accept-Encoding, User-Agent]\n" +
+            "\theaders: [Content-Type=*/*,Matched-Stub-Id=" + stubMapping.getId() + ",Transfer-Encoding=chunked,Vary=Accept-Encoding, User-Agent]\n" +
             "\tmedia type: */*\n" +
             "\tbody: {\"response\":{\"code\":\"SUCCESS\",\"data\":{\"accessToken\":\"accessTokenValue\",\"refreshToken\":\"refreshTokenValue\",\"expiresIn\":480,\"refreshExpiresIn\":21600,\"tokenType\":\"Bearer\"}}}";
         String actualMessage = null;

--- a/smartling-api-commons/src/test/java/com/smartling/api/v2/auth/AuthenticationIntegrationTest.java
+++ b/smartling-api-commons/src/test/java/com/smartling/api/v2/auth/AuthenticationIntegrationTest.java
@@ -133,7 +133,7 @@ public class AuthenticationIntegrationTest
             "\tgenericType: class com.smartling.api.v2.authentication.pto.Authentication\n" +
             "\tannotations: [\n" +
             "\t\t@javax.ws.rs.POST()\n" +
-            "\t\t@javax.ws.rs.Path(value=\"/authenticate\")\n" +
+            "\t\t@javax.ws.rs.Path(\"/authenticate\")\n" +
             "\t]\n" +
             "\theaders: [Content-Type=*/*,Matched-Stub-Id=" + stubMapping.getId() + ",Server=Jetty(9.2.28.v20190418),Transfer-Encoding=chunked,Vary=Accept-Encoding, User-Agent]\n" +
             "\tmedia type: */*\n" +

--- a/smartling-api-commons/src/test/java/com/smartling/api/v2/client/unmarshal/DetailsDeserializerTest.java
+++ b/smartling-api-commons/src/test/java/com/smartling/api/v2/client/unmarshal/DetailsDeserializerTest.java
@@ -56,6 +56,7 @@ public class DetailsDeserializerTest
     public void testDeserializeNullBody() throws Exception
     {
         when(node.getNodeType()).thenReturn(JsonNodeType.NULL);
+        when(node.isNull()).thenReturn(true);
         final Details details = detailsDeserializer.deserialize(parser, null);
         assertNull(details);
     }

--- a/smartling-attachments-api/src/test/java/com/smartling/api/attachments/v2/AttachmentsApiTest.java
+++ b/smartling-attachments-api/src/test/java/com/smartling/api/attachments/v2/AttachmentsApiTest.java
@@ -183,16 +183,6 @@ public class AttachmentsApiTest
             "\r\n" +
             "content\r\n" +
             partSeparator + "\r\n" +
-            "Content-Disposition: form-data; name=\"name\"\r\n" +
-            "Content-Type: text/plain\r\n" +
-            "\r\n" +
-            "test.txt\r\n" +
-            partSeparator + "\r\n" +
-            "Content-Disposition: form-data; name=\"description\"\r\n" +
-            "Content-Type: text/plain\r\n" +
-            "\r\n" +
-            "description\r\n" +
-            partSeparator + "\r\n" +
             "Content-Disposition: form-data; name=\"entityUids\"\r\n" +
             "Content-Type: text/plain\r\n" +
             "\r\n" +
@@ -202,6 +192,16 @@ public class AttachmentsApiTest
             "Content-Type: text/plain\r\n" +
             "\r\n" +
             "jobUuid2\r\n" +
+            partSeparator + "\r\n" +
+            "Content-Disposition: form-data; name=\"name\"\r\n" +
+            "Content-Type: text/plain\r\n" +
+            "\r\n" +
+            "test.txt\r\n" +
+            partSeparator + "\r\n" +
+            "Content-Disposition: form-data; name=\"description\"\r\n" +
+            "Content-Type: text/plain\r\n" +
+            "\r\n" +
+            "description\r\n" +
             partSeparator + "--");
 
         assertEquals(expectedPTO.getAttachmentUid(), response.getAttachmentUid());

--- a/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/util/FileUploadProxyUtils.java
+++ b/smartling-job-batches-api/src/main/java/com/smartling/api/jobbatches/util/FileUploadProxyUtils.java
@@ -8,7 +8,6 @@ import org.jboss.resteasy.annotations.providers.multipart.PartFilename;
 import org.jboss.resteasy.annotations.providers.multipart.PartType;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 import org.jboss.resteasy.client.jaxrs.internal.ClientResponse;
-import org.jboss.resteasy.plugins.providers.multipart.FieldEnablerPrivilegedAction;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
 
 import javax.ws.rs.FormParam;
@@ -21,7 +20,6 @@ import java.io.IOException;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.security.AccessController;
 import java.util.Map;
 
 @Slf4j
@@ -65,7 +63,7 @@ public class FileUploadProxyUtils
     {
         for (Field field : type.getDeclaredFields())
         {
-            AccessController.doPrivileged(new FieldEnablerPrivilegedAction(field));
+            field.setAccessible(true);
             Object value = getFieldValue(field, obj);
             if (value == null)
             {


### PR DESCRIPTION
**To All**: I have no plans to merge this PR; it is only for visibility.

There is no way to keep `smartling-api-commons` free of CVEs while continuing to support Java 8. I made only the necessary changes to migrate the code and dependencies to Java 17. This means that the SDK will exist in two versions, requiring each new development (endpoint) to be implemented twice.

I'd like to encourage all teams to migrate their services from 1.x to the new 2.x (when it is released).