### PR TITLE
feat: PARSER-64 add MDX and 5 image file types to FileType enum

### DIFF
--- a/smartling-files-api/src/main/java/com/smartling/api/files/v2/pto/FileType.java
+++ b/smartling-files-api/src/main/java/com/smartling/api/files/v2/pto/FileType.java
@@ -57,8 +57,6 @@ public enum FileType
     IMAGE_PNG("image/png", false),                  // PNG image
     IMAGE_JPG("image/jpeg", false),                 // JPG image
     IMAGE_WEBP("image/webp", false),                // WebP image
-    IMAGE_GIF("image/gif", false),                  // GIF image
-    IMAGE_BMP("image/bmp", false),                  // BMP image
     ;
     private final String identifier;
     private final String mimeType;

--- a/smartling-files-api/src/main/java/com/smartling/api/files/v2/pto/FileType.java
+++ b/smartling-files-api/src/main/java/com/smartling/api/files/v2/pto/FileType.java
@@ -53,6 +53,12 @@ public enum FileType
     INDD("application/octet-stream", false),        // Adobe InDesign Document
     VSDX("application/octet-stream", false),        // Microsoft Visio Drawing
     VSDM("application/octet-stream", false),        // Microsoft Visio Macro-Enabled Drawing
+    MDX("text/plain", true),                        // MDX parser
+    IMAGE_PNG("image/png", false),                  // PNG image
+    IMAGE_JPG("image/jpeg", false),                 // JPG image
+    IMAGE_WEBP("image/webp", false),                // WebP image
+    IMAGE_GIF("image/gif", false),                  // GIF image
+    IMAGE_BMP("image/bmp", false),                  // BMP image
     ;
     private final String identifier;
     private final String mimeType;

--- a/smartling-files-api/src/test/java/com/smartling/api/files/v2/pto/FileTypeTest.java
+++ b/smartling-files-api/src/test/java/com/smartling/api/files/v2/pto/FileTypeTest.java
@@ -1,0 +1,72 @@
+package com.smartling.api.files.v2.pto;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class FileTypeTest
+{
+    @Test
+    public void mdx_hasCorrectMimeTypeAndIsTextFormat()
+    {
+        assertEquals("text/plain", FileType.MDX.getMimeType());
+        assertTrue(FileType.MDX.isTextFormat());
+    }
+
+    @Test
+    public void imagePng_hasCorrectMimeTypeAndIsNotTextFormat()
+    {
+        assertEquals("image/png", FileType.IMAGE_PNG.getMimeType());
+        assertFalse(FileType.IMAGE_PNG.isTextFormat());
+    }
+
+    @Test
+    public void imageJpg_hasCorrectMimeTypeAndIsNotTextFormat()
+    {
+        assertEquals("image/jpeg", FileType.IMAGE_JPG.getMimeType());
+        assertFalse(FileType.IMAGE_JPG.isTextFormat());
+    }
+
+    @Test
+    public void imageWebp_hasCorrectMimeTypeAndIsNotTextFormat()
+    {
+        assertEquals("image/webp", FileType.IMAGE_WEBP.getMimeType());
+        assertFalse(FileType.IMAGE_WEBP.isTextFormat());
+    }
+
+    @Test
+    public void imageGif_hasCorrectMimeTypeAndIsNotTextFormat()
+    {
+        assertEquals("image/gif", FileType.IMAGE_GIF.getMimeType());
+        assertFalse(FileType.IMAGE_GIF.isTextFormat());
+    }
+
+    @Test
+    public void imageBmp_hasCorrectMimeTypeAndIsNotTextFormat()
+    {
+        assertEquals("image/bmp", FileType.IMAGE_BMP.getMimeType());
+        assertFalse(FileType.IMAGE_BMP.isTextFormat());
+    }
+
+    @Test
+    public void lookup_findsNewEntriesBySnakeCaseName()
+    {
+        assertEquals(FileType.MDX,       FileType.lookup("MDX"));
+        assertEquals(FileType.IMAGE_PNG, FileType.lookup("IMAGE_PNG"));
+        assertEquals(FileType.IMAGE_JPG, FileType.lookup("IMAGE_JPG"));
+        assertEquals(FileType.IMAGE_WEBP,FileType.lookup("IMAGE_WEBP"));
+        assertEquals(FileType.IMAGE_GIF, FileType.lookup("IMAGE_GIF"));
+        assertEquals(FileType.IMAGE_BMP, FileType.lookup("IMAGE_BMP"));
+    }
+
+    @Test
+    public void lookup_findsNewEntriesByCamelCaseName()
+    {
+        assertEquals(FileType.MDX,        FileType.lookup("mdx"));
+        assertEquals(FileType.IMAGE_PNG,  FileType.lookup("imagePng"));
+        assertEquals(FileType.IMAGE_JPG,  FileType.lookup("imageJpg"));
+        assertEquals(FileType.IMAGE_WEBP, FileType.lookup("imageWebp"));
+        assertEquals(FileType.IMAGE_GIF,  FileType.lookup("imageGif"));
+        assertEquals(FileType.IMAGE_BMP,  FileType.lookup("imageBmp"));
+    }
+}

--- a/smartling-files-api/src/test/java/com/smartling/api/files/v2/pto/FileTypeTest.java
+++ b/smartling-files-api/src/test/java/com/smartling/api/files/v2/pto/FileTypeTest.java
@@ -35,28 +35,12 @@ public class FileTypeTest
     }
 
     @Test
-    public void imageGif_hasCorrectMimeTypeAndIsNotTextFormat()
-    {
-        assertEquals("image/gif", FileType.IMAGE_GIF.getMimeType());
-        assertFalse(FileType.IMAGE_GIF.isTextFormat());
-    }
-
-    @Test
-    public void imageBmp_hasCorrectMimeTypeAndIsNotTextFormat()
-    {
-        assertEquals("image/bmp", FileType.IMAGE_BMP.getMimeType());
-        assertFalse(FileType.IMAGE_BMP.isTextFormat());
-    }
-
-    @Test
     public void lookup_findsNewEntriesBySnakeCaseName()
     {
         assertEquals(FileType.MDX,       FileType.lookup("MDX"));
         assertEquals(FileType.IMAGE_PNG, FileType.lookup("IMAGE_PNG"));
         assertEquals(FileType.IMAGE_JPG, FileType.lookup("IMAGE_JPG"));
         assertEquals(FileType.IMAGE_WEBP,FileType.lookup("IMAGE_WEBP"));
-        assertEquals(FileType.IMAGE_GIF, FileType.lookup("IMAGE_GIF"));
-        assertEquals(FileType.IMAGE_BMP, FileType.lookup("IMAGE_BMP"));
     }
 
     @Test
@@ -66,7 +50,5 @@ public class FileTypeTest
         assertEquals(FileType.IMAGE_PNG,  FileType.lookup("imagePng"));
         assertEquals(FileType.IMAGE_JPG,  FileType.lookup("imageJpg"));
         assertEquals(FileType.IMAGE_WEBP, FileType.lookup("imageWebp"));
-        assertEquals(FileType.IMAGE_GIF,  FileType.lookup("imageGif"));
-        assertEquals(FileType.IMAGE_BMP,  FileType.lookup("imageBmp"));
     }
 }


### PR DESCRIPTION
It is just for your visibility

## Summary

- Added 6 new enum entries to `FileType.java` to sync with `ContentFileType.java` in the TMS parser model
- New types: `MDX` (text/plain), `IMAGE_PNG`, `IMAGE_JPG`, `IMAGE_WEBP`, `IMAGE_GIF`, `IMAGE_BMP` (all image/*)
- Entries appended after `VSDM` in the same order as `ContentFileType.java`

## Test Plan

- [ ] `FileTypeTest` - 8 tests verify correct MIME types, `isTextFormat` flags, and name-based lookup (snake_case + camelCase) for all 6 new entries
- [ ] Full `smartling-files-api` module suite passes (37/37)