### PR TITLE
fix: re-authenticate instead of returning a session-capped refreshed token

### DIFF
--- a/smartling-api-commons/src/main/java/com/smartling/api/v2/client/auth/Authenticator.java
+++ b/smartling-api-commons/src/main/java/com/smartling/api/v2/client/auth/Authenticator.java
@@ -88,7 +88,12 @@ public class Authenticator
             log.debug("Going to refresh access token.");
             try
             {
-                return refreshAccessToken();
+                String accessToken = refreshAccessToken();
+                if (!isSessionCapped())
+                {
+                    return accessToken;
+                }
+                log.info("Refreshed token has a session-capped lifetime ({}s); re-authenticating.", authentication.getRefreshExpiresIn());
             }
             catch (Exception e)
             {
@@ -114,6 +119,11 @@ public class Authenticator
             return false;
 
         return refreshExpiresAt > clock.currentTimeMillis();
+    }
+
+    boolean isSessionCapped()
+    {
+        return authentication.getRefreshExpiresIn() * 1000L < REFRESH_BEFORE_EXPIRES_MS;
     }
 
     public synchronized void invalidate()

--- a/smartling-api-commons/src/main/java/com/smartling/api/v2/client/auth/Authenticator.java
+++ b/smartling-api-commons/src/main/java/com/smartling/api/v2/client/auth/Authenticator.java
@@ -93,7 +93,7 @@ public class Authenticator
                 {
                     return accessToken;
                 }
-                log.info("Refreshed token has a session-capped lifetime ({}s); re-authenticating.", authentication.getRefreshExpiresIn());
+                log.debug("Refreshed token has a session-capped lifetime ({}s); re-authenticating.", authentication.getRefreshExpiresIn());
             }
             catch (Exception e)
             {

--- a/smartling-api-commons/src/test/java/com/smartling/api/v2/client/auth/AuthenticatorTest.java
+++ b/smartling-api-commons/src/test/java/com/smartling/api/v2/client/auth/AuthenticatorTest.java
@@ -227,4 +227,36 @@ public class AuthenticatorTest
         verify(authenticationApi, times(1)).authenticate(any(AuthenticationRequest.class));
         verify(authenticationApi, times(1)).refresh(any(AuthenticationRefreshRequest.class));
     }
+
+    @Test
+    public void refreshOrRequestNewAccessTokenSessionCappedTriggersReAuth()
+    {
+        when(clock.currentTimeMillis()).thenReturn(System.currentTimeMillis());
+        authenticator.getAccessToken();
+
+        Authentication cappedAuth = new Authentication("cappedAccessToken", "cappedRefreshToken", ACCESS_TOKEN_TTL, 45, "bearer");
+        when(authenticationApi.refresh(any(AuthenticationRefreshRequest.class))).thenReturn(cappedAuth);
+
+        String accessToken = authenticator.refreshOrRequestNewAccessToken(true);
+
+        verify(authenticationApi).refresh(any(AuthenticationRefreshRequest.class));
+        verify(authenticationApi, times(2)).authenticate(any(AuthenticationRequest.class));
+        assertEquals(auth.getAccessToken(), accessToken);
+    }
+
+    @Test
+    public void refreshOrRequestNewAccessTokenNormalRefreshUnaffected()
+    {
+        when(clock.currentTimeMillis()).thenReturn(System.currentTimeMillis());
+        authenticator.getAccessToken();
+
+        Authentication refreshedAuth = new Authentication("refreshedAccessToken", "refreshedRefreshToken", ACCESS_TOKEN_TTL, REFRESH_TOKEN_TTL, "bearer");
+        when(authenticationApi.refresh(any(AuthenticationRefreshRequest.class))).thenReturn(refreshedAuth);
+
+        String accessToken = authenticator.refreshOrRequestNewAccessToken(true);
+
+        verify(authenticationApi).refresh(any(AuthenticationRefreshRequest.class));
+        verify(authenticationApi, times(1)).authenticate(any(AuthenticationRequest.class));
+        assertEquals(refreshedAuth.getAccessToken(), accessToken);
+    }
 }


### PR DESCRIPTION
## Problem

### Background: SSO session max lifespan

Every access/refresh token pair issued by Keycloak is tied to an underlying SSO session, and that session has a **max lifespan** (our Keycloak realm has this set to 12h). A refresh token can be used to mint new access tokens repeatedly, but only for as long as its parent session is alive — Keycloak will never issue a refreshed token that outlives the session's max lifespan, no matter how large the client's configured refresh-token TTL is. So as a session approaches its 12h cutoff, each successive refresh returns a token whose lifetime is capped to "whatever time is left on the session," which keeps shrinking toward zero rather than resetting to the normal TTL.

### What changed

This behavior is new with our Keycloak 26 migration — Keycloak 1.9 did not cap a refreshed token's lifetime to the remaining session time, so `Authenticator` never had to deal with a refresh returning a shorter-than-usual token. Keycloak 26 does cap it, which exposes a gap in `Authenticator`'s refresh handling:

Once a session gets within 90 seconds of ending, `Authenticator.isValid()` treats every access token as already expired, so each outgoing call triggers a refresh — and the refresh comes back capped just as short. This repeats on every call for as long as the session has under 90 seconds left, producing a burst of refresh calls that tracks request rate until the session hard-expires.

`refreshOrRequestNewAccessToken` only fell back to a full re-authenticate when the refresh call *threw* — never when the refresh succeeded but returned a session-capped token, so this refresh-loop had no escape hatch.

We're already observing this in the wild: a number of services are spamming the auth service with heavy bursts of refresh calls as their sessions near the 12h mark, matching this exact pattern.

This is the `java-api-sdk` counterpart to [AUT-1473](https://smartling.atlassian.net/browse/AUT-1473), which addresses the same issue in `authentication-api-sdk`.




[AUT-1473]: https://smartling.atlassian.net/browse/AUT-1473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ